### PR TITLE
adjusted initVersion to ensure a clean semver version is used

### DIFF
--- a/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -91,6 +91,7 @@ export class ZabbixAPIConnector {
     if (!this.getVersionPromise) {
       this.getVersionPromise = Promise.resolve(
         this.getVersion().then(version => {
+          version = semver.clean(version);
           if (version) {
             console.log(`Zabbix version detected: ${version}`);
           } else {


### PR DESCRIPTION
Hi @alexanderzobnin,

This PR fixes an issue where an invalid version error is returned if the Zabbix API returns the semver plus a date.

Related issue: https://github.com/alexanderzobnin/grafana-zabbix/issues/1385 

