### PR TITLE
Auth: Able to use API tokens for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change Log
 
-## [4.4.0] - 2023-06-06
+## [4.4.0] - Unreleased
 
 ### Added
 
-- Enables PDC for zabbix datasource, [#1653](https://github.com/alexanderzobnin/grafana-zabbix/issues/1653)
+- Support for secure socks proxy, [#1653](https://github.com/alexanderzobnin/grafana-zabbix/issues/1653)
+- Able to use API tokens for authentication, [#1513](https://github.com/alexanderzobnin/grafana-zabbix/issues/1513)
 
 ## [4.3.1] - 2023-03-23
 

--- a/pkg/datasource/zabbix_test.go
+++ b/pkg/datasource/zabbix_test.go
@@ -3,6 +3,7 @@ package datasource
 import (
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/settings"
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/zabbix"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
@@ -13,7 +14,7 @@ var basicDatasourceInfo = &backend.DataSourceInstanceSettings{
 	ID:       1,
 	Name:     "TestDatasource",
 	URL:      "http://zabbix.org/zabbix",
-	JSONData: []byte(`{"username":"username", "password":"password", "cacheTTL":"10m"}`),
+	JSONData: []byte(`{"username":"username", "password":"password", "cacheTTL":"10m", "authType":"token"}`),
 }
 
 func mockZabbixQuery(method string, params zabbix.ZabbixAPIParams) *zabbix.ZabbixAPIRequest {

--- a/pkg/settings/models.go
+++ b/pkg/settings/models.go
@@ -2,8 +2,14 @@ package settings
 
 import "time"
 
+const (
+	AuthTypeUserLogin = "userLogin"
+	AuthTypeToken     = "token"
+)
+
 // ZabbixDatasourceSettingsDTO model
 type ZabbixDatasourceSettingsDTO struct {
+	AuthType    string      `json:"authType"`
 	Trends      bool        `json:"trends"`
 	TrendsFrom  string      `json:"trendsFrom"`
 	TrendsRange string      `json:"trendsRange"`
@@ -16,6 +22,7 @@ type ZabbixDatasourceSettingsDTO struct {
 
 // ZabbixDatasourceSettings model
 type ZabbixDatasourceSettings struct {
+	AuthType    string
 	Trends      bool
 	TrendsFrom  time.Duration
 	TrendsRange time.Duration

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -3,10 +3,12 @@ package settings
 import (
 	"encoding/json"
 	"errors"
-	"github.com/alexanderzobnin/grafana-zabbix/pkg/gtime"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"strconv"
 	"time"
+
+	"github.com/alexanderzobnin/grafana-zabbix/pkg/gtime"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 func ReadZabbixSettings(dsInstanceSettings *backend.DataSourceInstanceSettings) (*ZabbixDatasourceSettings, error) {
@@ -15,6 +17,10 @@ func ReadZabbixSettings(dsInstanceSettings *backend.DataSourceInstanceSettings) 
 	err := json.Unmarshal(dsInstanceSettings.JSONData, &zabbixSettingsDTO)
 	if err != nil {
 		return nil, err
+	}
+
+	if zabbixSettingsDTO.AuthType == "" {
+		zabbixSettingsDTO.AuthType = AuthTypeUserLogin
 	}
 
 	if zabbixSettingsDTO.TrendsFrom == "" {
@@ -65,6 +71,7 @@ func ReadZabbixSettings(dsInstanceSettings *backend.DataSourceInstanceSettings) 
 	}
 
 	zabbixSettings := &ZabbixDatasourceSettings{
+		AuthType:                zabbixSettingsDTO.AuthType,
 		Trends:                  zabbixSettingsDTO.Trends,
 		TrendsFrom:              trendsFrom,
 		TrendsRange:             trendsRange,

--- a/pkg/zabbix/zabbix_test.go
+++ b/pkg/zabbix/zabbix_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 var basicDatasourceInfo = &backend.DataSourceInstanceSettings{
@@ -19,7 +20,7 @@ var emptyParams = map[string]interface{}{}
 
 func TestLogin(t *testing.T) {
 	zabbixClient, _ := MockZabbixClient(basicDatasourceInfo, `{"result":"secretauth"}`, 200)
-	err := zabbixClient.Login(context.Background())
+	err := zabbixClient.Authenticate(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, "secretauth", zabbixClient.api.GetAuth())
@@ -27,7 +28,7 @@ func TestLogin(t *testing.T) {
 
 func TestLoginError(t *testing.T) {
 	zabbixClient, _ := MockZabbixClient(basicDatasourceInfo, `{"result":""}`, 500)
-	err := zabbixClient.Login(context.Background())
+	err := zabbixClient.Authenticate(context.Background())
 
 	assert.Error(t, err)
 	assert.Equal(t, "", zabbixClient.api.GetAuth())

--- a/pkg/zabbixapi/zabbix_api.go
+++ b/pkg/zabbixapi/zabbix_api.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/metrics"
 	"github.com/bitly/go-simplejson"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"golang.org/x/net/context/ctxhttp"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 var (
@@ -165,6 +166,15 @@ func (api *ZabbixAPI) Authenticate(ctx context.Context, username string, passwor
 	}
 
 	api.SetAuth(auth)
+	return nil
+}
+
+// AuthenticateWithToken performs authentication with API token.
+func (api *ZabbixAPI) AuthenticateWithToken(ctx context.Context, token string) error {
+	if token == "" {
+		return errors.New("API token is empty")
+	}
+	api.SetAuth(token)
 	return nil
 }
 

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -1,6 +1,7 @@
 import { BusEventWithPayload, DataQuery, DataSourceJsonData, DataSourceRef, SelectableValue } from '@grafana/data';
 
 export interface ZabbixDSOptions extends DataSourceJsonData {
+  authType?: ZabbixAuthType;
   username: string;
   password?: string;
   trends: boolean;
@@ -19,6 +20,7 @@ export interface ZabbixDSOptions extends DataSourceJsonData {
 
 export interface ZabbixSecureJSONData {
   password?: string;
+  apiToken?: string;
 }
 
 export interface ZabbixConnectionInfo {
@@ -407,4 +409,9 @@ export interface ZBXAlert {
 
 export class ZBXQueryUpdatedEvent extends BusEventWithPayload<any> {
   static type = 'zbx-query-updated';
+}
+
+export enum ZabbixAuthType {
+  UserLogin = 'userLogin',
+  Token = 'token',
 }


### PR DESCRIPTION
This PR adds API tokens authentication introduced in Zabbix 5.4.

Fixes #1513
