### PR TITLE
track executed queries and panel clicks

### DIFF
--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -26,6 +26,7 @@ import {
   toDataFrame,
 } from '@grafana/data';
 import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
+import { trackRequest } from './tracking';
 
 export class ZabbixDatasource extends DataSourceApi<ZabbixMetricsQuery, ZabbixDSOptions> {
   name: string;
@@ -113,6 +114,8 @@ export class ZabbixDatasource extends DataSourceApi<ZabbixMetricsQuery, ZabbixDS
    * @return {Object} Grafana metrics object with timeseries data for each target.
    */
   query(request: DataQueryRequest<ZabbixMetricsQuery>) {
+    trackRequest(request);
+
     // Migrate old targets
     const requestTargets = request.targets.map((t) => {
       // Prevent changes of original object

--- a/src/datasource/specs/datasource.spec.ts
+++ b/src/datasource/specs/datasource.spec.ts
@@ -15,6 +15,7 @@ jest.mock(
     getTemplateSrv: () => ({
       replace: jest.fn().mockImplementation((query) => query),
     }),
+    reportInteraction: jest.fn(),
   }),
   { virtual: true }
 );

--- a/src/datasource/tracking.ts
+++ b/src/datasource/tracking.ts
@@ -1,6 +1,15 @@
 import { DataQueryRequest } from '@grafana/data';
 import { ZabbixMetricsQuery } from './types';
 import { reportInteraction } from '@grafana/runtime';
+import {
+  MODE_ITEMID,
+  MODE_ITSERVICE,
+  MODE_MACROS,
+  MODE_METRICS,
+  MODE_PROBLEMS,
+  MODE_TEXT,
+  MODE_TRIGGERS,
+} from './constants';
 
 export const trackRequest = (request: DataQueryRequest<ZabbixMetricsQuery>): void => {
   request.targets.forEach((target) => {
@@ -9,54 +18,26 @@ export const trackRequest = (request: DataQueryRequest<ZabbixMetricsQuery>): voi
     };
 
     switch (target.queryType) {
-      case '0':
-      case '1':
-      case '3':
-        if (target.queryType === '0') {
-          properties.queryType = 'Metrics';
-        } else if (target.queryType === '1') {
-          properties.queryType = 'Services';
-        } else if (target.queryType === '3') {
-          properties.queryType = 'Item Id';
-        }
-        properties.trends = target.options.useTrends;
-        properties.showDisabledItems = target.options.showDisabledItems;
-        properties.useZabbixValueMapping = target.options.useZabbixValueMapping;
-        properties.disableDataAlignment = target.options.disableDataAlignment;
+      case MODE_METRICS:
+        properties.queryType = 'Metrics';
         break;
-      case '2':
+      case MODE_ITSERVICE:
+        properties.queryType = 'Services';
+        break;
+      case MODE_TEXT:
         properties.queryType = 'Text';
-        properties.showDisabledItems = target.options.showDisabledItems;
         break;
-      case '4':
+      case MODE_ITEMID:
+        properties.queryType = 'Item Id';
+        break;
+      case MODE_TRIGGERS:
         properties.queryType = 'Triggers';
-
-        if (target.options.acknowledged === 0) {
-          properties.acknowledged = 'unacknowledged';
-        } else if (target.options.acknowledged === 1) {
-          properties.acknowledged = 'acknowledged';
-        } else if (target.options.acknowledged === 2) {
-          properties.acknowledged = 'all triggers';
-        }
-
-        properties.useTimeRange = target.options.useTimeRange ?? false;
         break;
-      case '5':
+      case MODE_PROBLEMS:
         properties.queryType = 'Problems';
-
-        if (target.options.acknowledged === 0) {
-          properties.acknowledged = 'unacknowledged';
-        } else if (target.options.acknowledged === 1) {
-          properties.acknowledged = 'acknowledged';
-        } else if (target.options.acknowledged === 2) {
-          properties.acknowledged = 'all triggers';
-        }
-
-        properties.sortProblems = target.options.sortProblems;
-        properties.useTimeRange = target.options.useTimeRange;
-        properties.hostsInMaintenance = target.options.hostsInMaintenance;
-        properties.hostProxy = target.options.hostProxy;
-        properties.limit = target.options.limit;
+        break;
+      case MODE_MACROS:
+        properties.queryType = 'Macros';
         break;
     }
 

--- a/src/datasource/tracking.ts
+++ b/src/datasource/tracking.ts
@@ -1,0 +1,65 @@
+import { DataQueryRequest } from '@grafana/data';
+import { ZabbixMetricsQuery } from './types';
+import { reportInteraction } from '@grafana/runtime';
+
+export const trackRequest = (request: DataQueryRequest<ZabbixMetricsQuery>): void => {
+  request.targets.forEach((target) => {
+    const properties: any = {
+      app: request.app,
+    };
+
+    switch (target.queryType) {
+      case '0':
+      case '1':
+      case '3':
+        if (target.queryType === '0') {
+          properties.queryType = 'Metrics';
+        } else if (target.queryType === '1') {
+          properties.queryType = 'Services';
+        } else if (target.queryType === '3') {
+          properties.queryType = 'Item Id';
+        }
+        properties.trends = target.options.useTrends;
+        properties.showDisabledItems = target.options.showDisabledItems;
+        properties.useZabbixValueMapping = target.options.useZabbixValueMapping;
+        properties.disableDataAlignment = target.options.disableDataAlignment;
+        break;
+      case '2':
+        properties.queryType = 'Text';
+        properties.showDisabledItems = target.options.showDisabledItems;
+        break;
+      case '4':
+        properties.queryType = 'Triggers';
+
+        if (target.options.acknowledged === 0) {
+          properties.acknowledged = 'unacknowledged';
+        } else if (target.options.acknowledged === 1) {
+          properties.acknowledged = 'acknowledged';
+        } else if (target.options.acknowledged === 2) {
+          properties.acknowledged = 'all triggers';
+        }
+
+        properties.useTimeRange = target.options.useTimeRange ?? false;
+        break;
+      case '5':
+        properties.queryType = 'Problems';
+
+        if (target.options.acknowledged === 0) {
+          properties.acknowledged = 'unacknowledged';
+        } else if (target.options.acknowledged === 1) {
+          properties.acknowledged = 'acknowledged';
+        } else if (target.options.acknowledged === 2) {
+          properties.acknowledged = 'all triggers';
+        }
+
+        properties.sortProblems = target.options.sortProblems;
+        properties.useTimeRange = target.options.useTimeRange;
+        properties.hostsInMaintenance = target.options.hostsInMaintenance;
+        properties.hostProxy = target.options.hostProxy;
+        properties.limit = target.options.limit;
+        break;
+    }
+
+    reportInteraction('grafana_zabbix_query_executed', properties);
+  });
+};

--- a/src/panel-triggers/components/Problems/Problems.tsx
+++ b/src/panel-triggers/components/Problems/Problems.tsx
@@ -14,6 +14,7 @@ import { ProblemDTO, ZBXAlert, ZBXEvent, ZBXTag } from '../../../datasource/type
 import { APIExecuteScriptResponse, ZBXScript } from '../../../datasource/zabbix/connectors/zabbix_api/types';
 import { AckCell } from './AckCell';
 import { DataSourceRef, TimeRange } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 export interface ProblemListProps {
   problems: ProblemDTO[];
@@ -77,6 +78,8 @@ export default class ProblemList extends PureComponent<ProblemListProps, Problem
   };
 
   handleExpandedChange = (expanded: any, event: any) => {
+    reportInteraction('grafana_zabbix_panel_row_expanded', {});
+
     const { problems, pageSize } = this.props;
     const { page } = this.state;
     const expandedProblems = {};
@@ -259,7 +262,13 @@ export default class ProblemList extends PureComponent<ProblemListProps, Problem
           )}
           expanded={this.getExpandedPage(this.state.page)}
           onExpandedChange={this.handleExpandedChange}
-          onPageChange={(page) => this.setState({ page })}
+          onPageChange={(page) => {
+            reportInteraction('grafana_zabbix_panel_page_change', {
+              action: page > this.state.page ? 'next' : 'prev',
+            });
+
+            this.setState({ page });
+          }}
           onPageSizeChange={this.handlePageSizeChange}
           onResizedChange={this.handleResizedChange}
         />


### PR DESCRIPTION
track executed queries so we can view some stats around the datasource
this includes but not limited to:
- how many queries are sent
- how often each query type is used
- etc.

Fixes [#72899](https://github.com/grafana/grafana/issues/72899)


