### PR TITLE
Doc: Fix broken link in query editor and doc

### DIFF
--- a/src/datasource/components/FunctionEditor/FunctionEditorControls.tsx
+++ b/src/datasource/components/FunctionEditor/FunctionEditorControls.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Icon } from '@grafana/ui';
 import { MetricFunc } from '../../types';
 
-const DOCS_FUNC_REF_URL = 'https://alexanderzobnin.github.io/grafana-zabbix/reference/functions/';
+const DOCS_FUNC_REF_URL = 'https://grafana.github.io/grafana-zabbix/reference/functions/';
 
 export interface FunctionEditorControlsProps {
   onMoveLeft: (func: MetricFunc) => void;

--- a/src/datasource/query_help.md
+++ b/src/datasource/query_help.md
@@ -32,4 +32,4 @@ Active triggers count for selected hosts or table data like Zabbix _System statu
 
 #### Documentation links:
 
-[Grafana-Zabbix Documentation](https://alexanderzobnin.github.io/grafana-zabbix)
+[Grafana-Zabbix Documentation](https://grafana.github.io/grafana-zabbix)


### PR DESCRIPTION
Fixes #1700 by directing to new documentation at https://grafana.github.io/grafana-zabbix
