### PR TITLE
Don't track query requests on dashboard reload

### DIFF
--- a/src/datasource/tracking.ts
+++ b/src/datasource/tracking.ts
@@ -1,4 +1,4 @@
-import { DataQueryRequest } from '@grafana/data';
+import { CoreApp, DataQueryRequest } from '@grafana/data';
 import { ZabbixMetricsQuery } from './types';
 import { reportInteraction } from '@grafana/runtime';
 import {
@@ -12,6 +12,10 @@ import {
 } from './constants';
 
 export const trackRequest = (request: DataQueryRequest<ZabbixMetricsQuery>): void => {
+  if (request.app === CoreApp.Dashboard || request.app === CoreApp.PanelViewer) {
+    return;
+  }
+
   request.targets.forEach((target) => {
     const properties: any = {
       app: request.app,


### PR DESCRIPTION
currently we track all query requests, this PR excludes requests on dashboard reload which improves performance.