### PR TITLE
feat: add generated jsonnet library

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -28,7 +28,11 @@
     "docs/**/*.yaml",
     "dashboards/**",
     "src/**",
-    "pkg/**"
+    "pkg/**",
+    "jsonnet/generator/jsonnetfile.json",
+    "jsonnet/generator/jsonnetfile.lock.json",
+    "jsonnet/generator/schema.json",
+    "jsonnet/zabbix-query-libsonnet/docs/**"
   ],
   "ignoreRegExpList": [
     "import\\s*\\((.|[\r\n])*?\\)",
@@ -73,6 +77,7 @@
     "timeshift",
     "templatig",
     "lastvalue",
-    "typeahead"
+    "typeahead",
+    "jsonnet"
   ]
 }

--- a/jsonnet/Makefile
+++ b/jsonnet/Makefile
@@ -1,0 +1,14 @@
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+generator/schema.json:
+	cd ../ && yarn install && \
+	npx --yes ts-json-schema-generator -p ./src/datasource/types.ts --tsconfig ./tsconfig.json -t ZabbixMetricsQuery -o $(ROOT_DIR)/generator/schema.json
+
+zabbix-query-libsonnet/main.libsonnet:
+	jsonnet -J generator/vendor -S $(ROOT_DIR)/generator/main.libsonnet \
+		| jsonnetfmt --no-use-implicit-plus - > $(ROOT_DIR)/zabbix-query-libsonnet/main.libsonnet
+
+zabbix-query-libsonnet/docs/:
+	@rm -rf zabbix-query-libsonnet/docs/ && \
+	jsonnet -J generator/vendor -S -c -m zabbix-query-libsonnet/docs/ \
+			--exec "(import 'doc-util/main.libsonnet').render(import 'zabbix-query-libsonnet/main.libsonnet')"

--- a/jsonnet/generator/jsonnetfile.json
+++ b/jsonnet/generator/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/crdsonnet/crdsonnet.git",
+          "subdir": "crdsonnet"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/jsonnet/generator/jsonnetfile.lock.json
+++ b/jsonnet/generator/jsonnetfile.lock.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/Duologic/jsonnet-libsonnet.git",
+          "subdir": ""
+        }
+      },
+      "version": "bd08bf5f0ffc156bd755b916367bceb7fbe3de03",
+      "sum": "ZYc3KrgzQIciDlQ786i2iHeqEZqjnB8KlPiX6w8Mp38="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/crdsonnet/crdsonnet.git",
+          "subdir": "crdsonnet"
+        }
+      },
+      "version": "940cd3c5ae0c5ee4f24268fb486ae12d2a0c606a",
+      "sum": "dS+RF4Jig6dEfqq4sJ37XlefV66W1syOz7QMCPEzbZk="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/crdsonnet/validate-libsonnet.git",
+          "subdir": ""
+        }
+      },
+      "version": "a78ca15fbfece3110c4807d1f059132ece01d97b",
+      "sum": "qYLH56MqvmgxE4YMNeTbuJ1XSsCpl1sumHN5x8IQv2I="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/docsonnet.git",
+          "subdir": "doc-util"
+        }
+      },
+      "version": "6ac6c69685b8c29c54515448eaca583da2d88150",
+      "sum": "BrAL/k23jq+xy9oA7TWIhUx07dsA/QLm3g7ktCwe//U="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "80bdea46b69cfbd5a6b57789ad856d3cb525e956",
+      "sum": "eUSd6nmI07Zl4pYuDnhasQ7Ua37HfHcBVItfvroVUGU="
+    }
+  ],
+  "legacyImports": false
+}

--- a/jsonnet/generator/main.libsonnet
+++ b/jsonnet/generator/main.libsonnet
@@ -1,0 +1,93 @@
+local schema = import './schema.json';
+
+local j = import 'github.com/Duologic/jsonnet-libsonnet/main.libsonnet';
+local jutils = import 'github.com/Duologic/jsonnet-libsonnet/utils.libsonnet';
+local crdsonnet = import 'github.com/crdsonnet/crdsonnet/crdsonnet/main.libsonnet';
+local astengine = import 'github.com/crdsonnet/crdsonnet/crdsonnet/renderEngines/ast.libsonnet';
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+local processor =
+  crdsonnet.processor.new()
+  + crdsonnet.processor.withRenderEngineType('ast');
+
+
+local unwrapFromCRDsonnet(astObject, title) =
+  jutils.get(
+    astObject,
+    title,
+    default=error 'field %s not found in ast' % title
+  ).expr;
+
+local addDoc(obj) =
+  j.object.members(
+    [
+      j.field.field(
+        j.fieldname.string('#'),
+        // render docsonnet as literal to avoid docsonnet dependency
+        j.literal(
+          d.package.new(
+            'zabbixQuery',
+            'https://github.com/grafana/grafana-zabbix/jsonnet/zabbix-query-libsonnet',
+            'Jsonnet library for creating Zabbix queries for Grafana.',
+            'main.libsonnet',
+            'main',
+          ),
+        ),
+        nobreak=true,
+      ),
+    ]
+    + std.filter(
+      // '#' docstring replaced by above
+      function(m) jutils.fieldnameValue(m.fieldname) != '#',
+      obj.members
+    )
+  );
+
+local hideDocs(obj) =
+  // The sub fields of these objects can be accessed directly.
+  // For example: `application.withFilter`
+  local objFields = [
+    'application',
+    'datasource',
+    'group',
+    'host',
+    'item',
+    'itemTag',
+    'macro',
+    'options',
+    'proxy',
+    'tags',
+    'trigger',
+    'triggers',
+  ];
+
+  local docsToHide =
+    std.map(
+      function(f) '#%s' % astengine.functionName(f),
+      objFields
+    )
+    + std.map(
+      function(f) '#%sMixin' % astengine.functionName(f),
+      objFields
+    );
+
+  j.object.members(
+    std.filter(
+      function(m)
+        !std.member(
+          docsToHide,
+          jutils.fieldnameValue(m.fieldname)
+        ),
+      obj.members,
+    )
+  );
+
+local render = crdsonnet.schema.render('item', schema, processor);
+
+local unwrapped = unwrapFromCRDsonnet(render, 'item');
+
+local renderWithDoc = addDoc(unwrapped);
+
+local renderWithHiddenDocs = hideDocs(renderWithDoc);
+
+renderWithHiddenDocs.toString(break='\n')

--- a/jsonnet/generator/schema.json
+++ b/jsonnet/generator/schema.json
@@ -1,0 +1,461 @@
+{
+  "$ref": "#/definitions/ZabbixMetricsQuery",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FuncDef": {
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "type": "string"
+        },
+        "defaultParams": {
+          "items": {
+            "type": [
+              "string",
+              "number"
+            ]
+          },
+          "type": "array"
+        },
+        "description": {
+          "type": "string"
+        },
+        "fake": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "params": {
+          "items": {
+            "$ref": "#/definitions/ParamDef"
+          },
+          "type": "array"
+        },
+        "shortName": {},
+        "unknown": {
+          "description": "True if the function was not found on the list of available function descriptions.",
+          "type": "boolean"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "params",
+        "defaultParams"
+      ],
+      "type": "object"
+    },
+    "MetricFunc": {
+      "additionalProperties": false,
+      "properties": {
+        "added": {
+          "type": "boolean"
+        },
+        "def": {
+          "$ref": "#/definitions/FuncDef"
+        },
+        "params": {
+          "items": {
+            "type": [
+              "string",
+              "number"
+            ]
+          },
+          "type": "array"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "params",
+        "def"
+      ],
+      "type": "object"
+    },
+    "ParamDef": {
+      "additionalProperties": false,
+      "properties": {
+        "multiple": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "options": {
+          "items": {
+            "type": [
+              "string",
+              "number"
+            ]
+          },
+          "type": "array"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ShowProblemTypes": {
+      "enum": [
+        "problems",
+        "recent",
+        "history"
+      ],
+      "type": "string"
+    },
+    "ZabbixMetricsQuery": {
+      "additionalProperties": false,
+      "properties": {
+        "application": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "countTriggersBy": {
+          "enum": [
+            "problems",
+            "items",
+            ""
+          ],
+          "type": "string"
+        },
+        "datasource": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "description": "The plugin type-id",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "Specific datasource instance",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "For mixed data sources the selected datasource is on the query level. For non mixed scenarios this is undefined. TODO find a better way to do this ^ that's friendly to schema TODO this shouldn't be unknown but DataSourceRef | null"
+        },
+        "datasourceId": {
+          "type": "number"
+        },
+        "evaltype": {
+          "$ref": "#/definitions/ZabbixTagEvalType"
+        },
+        "functions": {
+          "items": {
+            "$ref": "#/definitions/MetricFunc"
+          },
+          "type": "array"
+        },
+        "group": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "hide": {
+          "description": "true if query is disabled (ie should not be returned to the dashboard) Note this does not always imply that the query should not be executed since the results from a hidden query may be used as the input to other queries (SSE etc)",
+          "type": "boolean"
+        },
+        "host": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "hostFilter": {
+          "type": "string"
+        },
+        "itServiceFilter": {
+          "type": "string"
+        },
+        "item": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "itemFilter": {
+          "type": "string"
+        },
+        "itemTag": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "itemids": {
+          "type": "string"
+        },
+        "key": {
+          "description": "Unique, guid like, string (used only in explore mode)",
+          "type": "string"
+        },
+        "macro": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            },
+            "macro": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "macroFilter": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "number"
+        },
+        "options": {
+          "$ref": "#/definitions/ZabbixQueryOptions"
+        },
+        "proxy": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "queryType": {
+          "description": "Specify the query flavor TODO make this required and give it a default",
+          "type": "string"
+        },
+        "refId": {
+          "description": "A unique identifier for the query within the list of targets. In server side expressions, the refId is used as a variable name to identify results. By default, the UI will assign A->Z; however setting meaningful names may be useful.",
+          "type": "string"
+        },
+        "schema": {
+          "type": "number"
+        },
+        "showProblems": {
+          "$ref": "#/definitions/ShowProblemTypes"
+        },
+        "slaFilter": {
+          "type": "string"
+        },
+        "slaInterval": {
+          "type": "string"
+        },
+        "slaProperty": {},
+        "tags": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "textFilter": {
+          "type": "string"
+        },
+        "trigger": {
+          "additionalProperties": false,
+          "properties": {
+            "filter": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter"
+          ],
+          "type": "object"
+        },
+        "triggers": {
+          "additionalProperties": false,
+          "properties": {
+            "acknowledged": {
+              "type": "number"
+            },
+            "count": {
+              "type": "boolean"
+            },
+            "minSeverity": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "minSeverity",
+            "acknowledged",
+            "count"
+          ],
+          "type": "object"
+        },
+        "useCaptureGroups": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "application",
+        "datasourceId",
+        "group",
+        "host",
+        "item",
+        "itemTag",
+        "itemids",
+        "macro",
+        "mode",
+        "queryType",
+        "refId",
+        "schema",
+        "textFilter",
+        "useCaptureGroups"
+      ],
+      "type": "object"
+    },
+    "ZabbixQueryOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "acknowledged": {
+          "type": "number"
+        },
+        "count": {
+          "type": "boolean"
+        },
+        "disableDataAlignment": {
+          "type": "boolean"
+        },
+        "hideAcknowledged": {
+          "type": "boolean"
+        },
+        "hostProxy": {
+          "type": "boolean"
+        },
+        "hostsInMaintenance": {
+          "type": "boolean"
+        },
+        "limit": {
+          "type": "number"
+        },
+        "minSeverity": {
+          "type": "number"
+        },
+        "severities": {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "showDisabledItems": {
+          "type": "boolean"
+        },
+        "showHostname": {
+          "type": "boolean"
+        },
+        "showOkEvents": {
+          "type": "boolean"
+        },
+        "skipEmptyValues": {
+          "type": "boolean"
+        },
+        "sortProblems": {
+          "type": "string"
+        },
+        "useTimeRange": {
+          "type": "boolean"
+        },
+        "useTrends": {
+          "enum": [
+            "default",
+            "true",
+            "false"
+          ],
+          "type": "string"
+        },
+        "useZabbixValueMapping": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ZabbixTagEvalType": {
+      "enum": [
+        "0",
+        "2"
+      ],
+      "type": "string"
+    }
+  }
+}

--- a/jsonnet/zabbix-query-libsonnet/docs/README.md
+++ b/jsonnet/zabbix-query-libsonnet/docs/README.md
@@ -1,0 +1,810 @@
+# zabbixQuery
+
+Jsonnet library for creating Zabbix queries for Grafana.
+## Install
+
+```
+jb install https://github.com/grafana/grafana-zabbix/jsonnet/zabbix-query-libsonnet@main
+```
+
+## Usage
+
+```jsonnet
+local zabbixQuery = import "https://github.com/grafana/grafana-zabbix/jsonnet/zabbix-query-libsonnet/main.libsonnet"
+```
+
+
+## Subpackages
+
+* [functions](functions/index.md)
+
+## Index
+
+* [`fn withCountTriggersBy(value)`](#fn-withcounttriggersby)
+* [`fn withDatasourceId(value)`](#fn-withdatasourceid)
+* [`fn withEvaltype(value)`](#fn-withevaltype)
+* [`fn withFunctions(value)`](#fn-withfunctions)
+* [`fn withFunctionsMixin(value)`](#fn-withfunctionsmixin)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withHostFilter(value)`](#fn-withhostfilter)
+* [`fn withItServiceFilter(value)`](#fn-withitservicefilter)
+* [`fn withItemFilter(value)`](#fn-withitemfilter)
+* [`fn withItemids(value)`](#fn-withitemids)
+* [`fn withKey(value)`](#fn-withkey)
+* [`fn withMacroFilter(value)`](#fn-withmacrofilter)
+* [`fn withMode(value)`](#fn-withmode)
+* [`fn withQueryType(value)`](#fn-withquerytype)
+* [`fn withRefId(value)`](#fn-withrefid)
+* [`fn withSchema(value)`](#fn-withschema)
+* [`fn withShowProblems(value)`](#fn-withshowproblems)
+* [`fn withSlaFilter(value)`](#fn-withslafilter)
+* [`fn withSlaInterval(value)`](#fn-withslainterval)
+* [`fn withSlaProperty(value)`](#fn-withslaproperty)
+* [`fn withTextFilter(value)`](#fn-withtextfilter)
+* [`fn withUseCaptureGroups(value=true)`](#fn-withusecapturegroups)
+* [`obj application`](#obj-application)
+  * [`fn withFilter(value)`](#fn-applicationwithfilter)
+  * [`fn withName(value)`](#fn-applicationwithname)
+* [`obj datasource`](#obj-datasource)
+  * [`fn withType(value)`](#fn-datasourcewithtype)
+  * [`fn withUid(value)`](#fn-datasourcewithuid)
+* [`obj group`](#obj-group)
+  * [`fn withFilter(value)`](#fn-groupwithfilter)
+  * [`fn withName(value)`](#fn-groupwithname)
+* [`obj host`](#obj-host)
+  * [`fn withFilter(value)`](#fn-hostwithfilter)
+  * [`fn withName(value)`](#fn-hostwithname)
+* [`obj item`](#obj-item)
+  * [`fn withFilter(value)`](#fn-itemwithfilter)
+  * [`fn withName(value)`](#fn-itemwithname)
+* [`obj itemTag`](#obj-itemtag)
+  * [`fn withFilter(value)`](#fn-itemtagwithfilter)
+  * [`fn withName(value)`](#fn-itemtagwithname)
+* [`obj macro`](#obj-macro)
+  * [`fn withFilter(value)`](#fn-macrowithfilter)
+  * [`fn withMacro(value)`](#fn-macrowithmacro)
+* [`obj options`](#obj-options)
+  * [`fn withAcknowledged(value)`](#fn-optionswithacknowledged)
+  * [`fn withCount(value=true)`](#fn-optionswithcount)
+  * [`fn withDisableDataAlignment(value=true)`](#fn-optionswithdisabledataalignment)
+  * [`fn withHideAcknowledged(value=true)`](#fn-optionswithhideacknowledged)
+  * [`fn withHostProxy(value=true)`](#fn-optionswithhostproxy)
+  * [`fn withHostsInMaintenance(value=true)`](#fn-optionswithhostsinmaintenance)
+  * [`fn withLimit(value)`](#fn-optionswithlimit)
+  * [`fn withMinSeverity(value)`](#fn-optionswithminseverity)
+  * [`fn withSeverities(value)`](#fn-optionswithseverities)
+  * [`fn withSeveritiesMixin(value)`](#fn-optionswithseveritiesmixin)
+  * [`fn withShowDisabledItems(value=true)`](#fn-optionswithshowdisableditems)
+  * [`fn withShowHostname(value=true)`](#fn-optionswithshowhostname)
+  * [`fn withShowOkEvents(value=true)`](#fn-optionswithshowokevents)
+  * [`fn withSkipEmptyValues(value=true)`](#fn-optionswithskipemptyvalues)
+  * [`fn withSortProblems(value)`](#fn-optionswithsortproblems)
+  * [`fn withUseTimeRange(value=true)`](#fn-optionswithusetimerange)
+  * [`fn withUseTrends(value)`](#fn-optionswithusetrends)
+  * [`fn withUseZabbixValueMapping(value=true)`](#fn-optionswithusezabbixvaluemapping)
+* [`obj proxy`](#obj-proxy)
+  * [`fn withFilter(value)`](#fn-proxywithfilter)
+* [`obj tags`](#obj-tags)
+  * [`fn withFilter(value)`](#fn-tagswithfilter)
+* [`obj trigger`](#obj-trigger)
+  * [`fn withFilter(value)`](#fn-triggerwithfilter)
+* [`obj triggers`](#obj-triggers)
+  * [`fn withAcknowledged(value)`](#fn-triggerswithacknowledged)
+  * [`fn withCount(value=true)`](#fn-triggerswithcount)
+  * [`fn withMinSeverity(value)`](#fn-triggerswithminseverity)
+
+## Fields
+
+### fn withCountTriggersBy
+
+```jsonnet
+withCountTriggersBy(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"problems"`, `"items"`, `""`
+
+
+### fn withDatasourceId
+
+```jsonnet
+withDatasourceId(value)
+```
+
+PARAMETERS:
+
+* **value** (`number`)
+
+
+### fn withEvaltype
+
+```jsonnet
+withEvaltype(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"0"`, `"2"`
+
+
+### fn withFunctions
+
+```jsonnet
+withFunctions(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withFunctionsMixin
+
+```jsonnet
+withFunctionsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withHide
+
+```jsonnet
+withHide(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+true if query is disabled (ie should not be returned to the dashboard) Note this does not always imply that the query should not be executed since the results from a hidden query may be used as the input to other queries (SSE etc)
+### fn withHostFilter
+
+```jsonnet
+withHostFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withItServiceFilter
+
+```jsonnet
+withItServiceFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withItemFilter
+
+```jsonnet
+withItemFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withItemids
+
+```jsonnet
+withItemids(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withKey
+
+```jsonnet
+withKey(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Unique, guid like, string (used only in explore mode)
+### fn withMacroFilter
+
+```jsonnet
+withMacroFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMode
+
+```jsonnet
+withMode(value)
+```
+
+PARAMETERS:
+
+* **value** (`number`)
+
+
+### fn withQueryType
+
+```jsonnet
+withQueryType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Specify the query flavor TODO make this required and give it a default
+### fn withRefId
+
+```jsonnet
+withRefId(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+A unique identifier for the query within the list of targets. In server side expressions, the refId is used as a variable name to identify results. By default, the UI will assign A->Z; however setting meaningful names may be useful.
+### fn withSchema
+
+```jsonnet
+withSchema(value)
+```
+
+PARAMETERS:
+
+* **value** (`number`)
+
+
+### fn withShowProblems
+
+```jsonnet
+withShowProblems(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"problems"`, `"recent"`, `"history"`
+
+
+### fn withSlaFilter
+
+```jsonnet
+withSlaFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withSlaInterval
+
+```jsonnet
+withSlaInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withSlaProperty
+
+```jsonnet
+withSlaProperty(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTextFilter
+
+```jsonnet
+withTextFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withUseCaptureGroups
+
+```jsonnet
+withUseCaptureGroups(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### obj application
+
+
+#### fn application.withFilter
+
+```jsonnet
+application.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn application.withName
+
+```jsonnet
+application.withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj datasource
+
+
+#### fn datasource.withType
+
+```jsonnet
+datasource.withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+The plugin type-id
+#### fn datasource.withUid
+
+```jsonnet
+datasource.withUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Specific datasource instance
+### obj group
+
+
+#### fn group.withFilter
+
+```jsonnet
+group.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn group.withName
+
+```jsonnet
+group.withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj host
+
+
+#### fn host.withFilter
+
+```jsonnet
+host.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn host.withName
+
+```jsonnet
+host.withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj item
+
+
+#### fn item.withFilter
+
+```jsonnet
+item.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn item.withName
+
+```jsonnet
+item.withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj itemTag
+
+
+#### fn itemTag.withFilter
+
+```jsonnet
+itemTag.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn itemTag.withName
+
+```jsonnet
+itemTag.withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj macro
+
+
+#### fn macro.withFilter
+
+```jsonnet
+macro.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn macro.withMacro
+
+```jsonnet
+macro.withMacro(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj options
+
+
+#### fn options.withAcknowledged
+
+```jsonnet
+options.withAcknowledged(value)
+```
+
+PARAMETERS:
+
+* **value** (`number`)
+
+
+#### fn options.withCount
+
+```jsonnet
+options.withCount(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withDisableDataAlignment
+
+```jsonnet
+options.withDisableDataAlignment(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withHideAcknowledged
+
+```jsonnet
+options.withHideAcknowledged(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withHostProxy
+
+```jsonnet
+options.withHostProxy(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withHostsInMaintenance
+
+```jsonnet
+options.withHostsInMaintenance(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withLimit
+
+```jsonnet
+options.withLimit(value)
+```
+
+PARAMETERS:
+
+* **value** (`number`)
+
+
+#### fn options.withMinSeverity
+
+```jsonnet
+options.withMinSeverity(value)
+```
+
+PARAMETERS:
+
+* **value** (`number`)
+
+
+#### fn options.withSeverities
+
+```jsonnet
+options.withSeverities(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+#### fn options.withSeveritiesMixin
+
+```jsonnet
+options.withSeveritiesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+#### fn options.withShowDisabledItems
+
+```jsonnet
+options.withShowDisabledItems(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withShowHostname
+
+```jsonnet
+options.withShowHostname(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withShowOkEvents
+
+```jsonnet
+options.withShowOkEvents(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withSkipEmptyValues
+
+```jsonnet
+options.withSkipEmptyValues(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withSortProblems
+
+```jsonnet
+options.withSortProblems(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn options.withUseTimeRange
+
+```jsonnet
+options.withUseTimeRange(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn options.withUseTrends
+
+```jsonnet
+options.withUseTrends(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"default"`, `"true"`, `"false"`
+
+
+#### fn options.withUseZabbixValueMapping
+
+```jsonnet
+options.withUseZabbixValueMapping(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### obj proxy
+
+
+#### fn proxy.withFilter
+
+```jsonnet
+proxy.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj tags
+
+
+#### fn tags.withFilter
+
+```jsonnet
+tags.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj trigger
+
+
+#### fn trigger.withFilter
+
+```jsonnet
+trigger.withFilter(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj triggers
+
+
+#### fn triggers.withAcknowledged
+
+```jsonnet
+triggers.withAcknowledged(value)
+```
+
+PARAMETERS:
+
+* **value** (`number`)
+
+
+#### fn triggers.withCount
+
+```jsonnet
+triggers.withCount(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn triggers.withMinSeverity
+
+```jsonnet
+triggers.withMinSeverity(value)
+```
+
+PARAMETERS:
+
+* **value** (`number`)
+

--- a/jsonnet/zabbix-query-libsonnet/docs/functions/def/params.md
+++ b/jsonnet/zabbix-query-libsonnet/docs/functions/def/params.md
@@ -1,0 +1,94 @@
+# params
+
+
+
+## Index
+
+* [`fn withMultiple(value=true)`](#fn-withmultiple)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withOptional(value=true)`](#fn-withoptional)
+* [`fn withOptions(value)`](#fn-withoptions)
+* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withVersion(value)`](#fn-withversion)
+
+## Fields
+
+### fn withMultiple
+
+```jsonnet
+withMultiple(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withOptional
+
+```jsonnet
+withOptional(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withOptions
+
+```jsonnet
+withOptions(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withOptionsMixin
+
+```jsonnet
+withOptionsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withVersion
+
+```jsonnet
+withVersion(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/jsonnet/zabbix-query-libsonnet/docs/functions/index.md
+++ b/jsonnet/zabbix-query-libsonnet/docs/functions/index.md
@@ -1,0 +1,223 @@
+# functions
+
+
+
+## Subpackages
+
+* [def.params](def/params.md)
+
+## Index
+
+* [`fn withAdded(value=true)`](#fn-withadded)
+* [`fn withDef(value)`](#fn-withdef)
+* [`fn withDefMixin(value)`](#fn-withdefmixin)
+* [`fn withParams(value)`](#fn-withparams)
+* [`fn withParamsMixin(value)`](#fn-withparamsmixin)
+* [`fn withText(value)`](#fn-withtext)
+* [`obj def`](#obj-def)
+  * [`fn withCategory(value)`](#fn-defwithcategory)
+  * [`fn withDefaultParams(value)`](#fn-defwithdefaultparams)
+  * [`fn withDefaultParamsMixin(value)`](#fn-defwithdefaultparamsmixin)
+  * [`fn withDescription(value)`](#fn-defwithdescription)
+  * [`fn withFake(value=true)`](#fn-defwithfake)
+  * [`fn withName(value)`](#fn-defwithname)
+  * [`fn withParams(value)`](#fn-defwithparams)
+  * [`fn withParamsMixin(value)`](#fn-defwithparamsmixin)
+  * [`fn withShortName(value)`](#fn-defwithshortname)
+  * [`fn withUnknown(value=true)`](#fn-defwithunknown)
+  * [`fn withVersion(value)`](#fn-defwithversion)
+
+## Fields
+
+### fn withAdded
+
+```jsonnet
+withAdded(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withDef
+
+```jsonnet
+withDef(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withDefMixin
+
+```jsonnet
+withDefMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withParams
+
+```jsonnet
+withParams(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withParamsMixin
+
+```jsonnet
+withParamsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withText
+
+```jsonnet
+withText(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### obj def
+
+
+#### fn def.withCategory
+
+```jsonnet
+def.withCategory(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn def.withDefaultParams
+
+```jsonnet
+def.withDefaultParams(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+#### fn def.withDefaultParamsMixin
+
+```jsonnet
+def.withDefaultParamsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+#### fn def.withDescription
+
+```jsonnet
+def.withDescription(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn def.withFake
+
+```jsonnet
+def.withFake(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+#### fn def.withName
+
+```jsonnet
+def.withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn def.withParams
+
+```jsonnet
+def.withParams(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+#### fn def.withParamsMixin
+
+```jsonnet
+def.withParamsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+#### fn def.withShortName
+
+```jsonnet
+def.withShortName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+#### fn def.withUnknown
+
+```jsonnet
+def.withUnknown(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+True if the function was not found on the list of available function descriptions.
+#### fn def.withVersion
+
+```jsonnet
+def.withVersion(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/jsonnet/zabbix-query-libsonnet/main.libsonnet
+++ b/jsonnet/zabbix-query-libsonnet/main.libsonnet
@@ -1,0 +1,266 @@
+{
+  '#': { filename: 'main.libsonnet', help: 'Jsonnet library for creating Zabbix queries for Grafana.\n## Install\n\n```\njb install https://github.com/grafana/grafana-zabbix/jsonnet/zabbix-query-libsonnet@main\n```\n\n## Usage\n\n```jsonnet\nlocal zabbixQuery = import "https://github.com/grafana/grafana-zabbix/jsonnet/zabbix-query-libsonnet/main.libsonnet"\n```\n', 'import': 'https://github.com/grafana/grafana-zabbix/jsonnet/zabbix-query-libsonnet/main.libsonnet', installTemplate: '\n## Install\n\n```\njb install %(url)s@%(version)s\n```\n', name: 'zabbixQuery', url: 'https://github.com/grafana/grafana-zabbix/jsonnet/zabbix-query-libsonnet', usageTemplate: '\n## Usage\n\n```jsonnet\nlocal %(name)s = import "%(import)s"\n```\n', version: 'main' },
+  withApplication(value): { application: value },
+  withApplicationMixin(value): { application+: value },
+  application+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { application+: { filter: value } },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withName(value): { application+: { name: value } },
+    },
+  '#withCountTriggersBy': { 'function': { args: [{ default: null, enums: ['problems', 'items', ''], name: 'value', type: ['string'] }], help: '' } },
+  withCountTriggersBy(value): { countTriggersBy: value },
+  withDatasource(value): { datasource: value },
+  withDatasourceMixin(value): { datasource+: value },
+  datasource+:
+    {
+      '#withType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: 'The plugin type-id' } },
+      withType(value): { datasource+: { type: value } },
+      '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: 'Specific datasource instance' } },
+      withUid(value): { datasource+: { uid: value } },
+    },
+  '#withDatasourceId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['number'] }], help: '' } },
+  withDatasourceId(value): { datasourceId: value },
+  '#withEvaltype': { 'function': { args: [{ default: null, enums: ['0', '2'], name: 'value', type: ['string'] }], help: '' } },
+  withEvaltype(value): { evaltype: value },
+  '#withFunctions': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+  withFunctions(value): { functions: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+  '#withFunctionsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+  withFunctionsMixin(value): { functions+: (if std.isArray(value)
+                                            then value
+                                            else [value]) },
+  functions+:
+    {
+      '#': { help: '', name: 'functions' },
+      '#withAdded': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withAdded(value=true): { added: value },
+      '#withDef': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['object'] }], help: '' } },
+      withDef(value): { def: value },
+      '#withDefMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['object'] }], help: '' } },
+      withDefMixin(value): { def+: value },
+      def+:
+        {
+          '#withCategory': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+          withCategory(value): { def+: { category: value } },
+          '#withDefaultParams': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+          withDefaultParams(value): { def+: { defaultParams: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) } },
+          '#withDefaultParamsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+          withDefaultParamsMixin(value): { def+: { defaultParams+: (if std.isArray(value)
+                                                                    then value
+                                                                    else [value]) } },
+          '#withDescription': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+          withDescription(value): { def+: { description: value } },
+          '#withFake': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+          withFake(value=true): { def+: { fake: value } },
+          '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+          withName(value): { def+: { name: value } },
+          '#withParams': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+          withParams(value): { def+: { params: (if std.isArray(value)
+                                                then value
+                                                else [value]) } },
+          '#withParamsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+          withParamsMixin(value): { def+: { params+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) } },
+          params+:
+            {
+              '#': { help: '', name: 'params' },
+              '#withMultiple': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+              withMultiple(value=true): { multiple: value },
+              '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+              withName(value): { name: value },
+              '#withOptional': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+              withOptional(value=true): { optional: value },
+              '#withOptions': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+              withOptions(value): { options: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+              '#withOptionsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+              withOptionsMixin(value): { options+: (if std.isArray(value)
+                                                    then value
+                                                    else [value]) },
+              '#withType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+              withType(value): { type: value },
+              '#withVersion': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+              withVersion(value): { version: value },
+            },
+          '#withShortName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+          withShortName(value): { def+: { shortName: value } },
+          '#withUnknown': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: 'True if the function was not found on the list of available function descriptions.' } },
+          withUnknown(value=true): { def+: { unknown: value } },
+          '#withVersion': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+          withVersion(value): { def+: { version: value } },
+        },
+      '#withParams': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+      withParams(value): { params: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withParamsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+      withParamsMixin(value): { params+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withText': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withText(value): { text: value },
+    },
+  withGroup(value): { group: value },
+  withGroupMixin(value): { group+: value },
+  group+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { group+: { filter: value } },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withName(value): { group+: { name: value } },
+    },
+  '#withHide': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: 'true if query is disabled (ie should not be returned to the dashboard) Note this does not always imply that the query should not be executed since the results from a hidden query may be used as the input to other queries (SSE etc)' } },
+  withHide(value=true): { hide: value },
+  withHost(value): { host: value },
+  withHostMixin(value): { host+: value },
+  host+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { host+: { filter: value } },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withName(value): { host+: { name: value } },
+    },
+  '#withHostFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withHostFilter(value): { hostFilter: value },
+  '#withItServiceFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withItServiceFilter(value): { itServiceFilter: value },
+  withItem(value): { item: value },
+  withItemMixin(value): { item+: value },
+  item+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { item+: { filter: value } },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withName(value): { item+: { name: value } },
+    },
+  '#withItemFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withItemFilter(value): { itemFilter: value },
+  withItemTag(value): { itemTag: value },
+  withItemTagMixin(value): { itemTag+: value },
+  itemTag+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { itemTag+: { filter: value } },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withName(value): { itemTag+: { name: value } },
+    },
+  '#withItemids': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withItemids(value): { itemids: value },
+  '#withKey': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: 'Unique, guid like, string (used only in explore mode)' } },
+  withKey(value): { key: value },
+  withMacro(value): { macro: value },
+  withMacroMixin(value): { macro+: value },
+  macro+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { macro+: { filter: value } },
+      '#withMacro': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withMacro(value): { macro: value },
+    },
+  '#withMacroFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withMacroFilter(value): { macroFilter: value },
+  '#withMode': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['number'] }], help: '' } },
+  withMode(value): { mode: value },
+  withOptions(value): { options: value },
+  withOptionsMixin(value): { options+: value },
+  options+:
+    {
+      '#withAcknowledged': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['number'] }], help: '' } },
+      withAcknowledged(value): { options+: { acknowledged: value } },
+      '#withCount': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withCount(value=true): { options+: { count: value } },
+      '#withDisableDataAlignment': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withDisableDataAlignment(value=true): { options+: { disableDataAlignment: value } },
+      '#withHideAcknowledged': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withHideAcknowledged(value=true): { options+: { hideAcknowledged: value } },
+      '#withHostProxy': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withHostProxy(value=true): { options+: { hostProxy: value } },
+      '#withHostsInMaintenance': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withHostsInMaintenance(value=true): { options+: { hostsInMaintenance: value } },
+      '#withLimit': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['number'] }], help: '' } },
+      withLimit(value): { options+: { limit: value } },
+      '#withMinSeverity': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['number'] }], help: '' } },
+      withMinSeverity(value): { options+: { minSeverity: value } },
+      '#withSeverities': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+      withSeverities(value): { options+: { severities: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) } },
+      '#withSeveritiesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['array'] }], help: '' } },
+      withSeveritiesMixin(value): { options+: { severities+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) } },
+      '#withShowDisabledItems': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withShowDisabledItems(value=true): { options+: { showDisabledItems: value } },
+      '#withShowHostname': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withShowHostname(value=true): { options+: { showHostname: value } },
+      '#withShowOkEvents': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withShowOkEvents(value=true): { options+: { showOkEvents: value } },
+      '#withSkipEmptyValues': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withSkipEmptyValues(value=true): { options+: { skipEmptyValues: value } },
+      '#withSortProblems': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withSortProblems(value): { options+: { sortProblems: value } },
+      '#withUseTimeRange': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withUseTimeRange(value=true): { options+: { useTimeRange: value } },
+      '#withUseTrends': { 'function': { args: [{ default: null, enums: ['default', 'true', 'false'], name: 'value', type: ['string'] }], help: '' } },
+      withUseTrends(value): { options+: { useTrends: value } },
+      '#withUseZabbixValueMapping': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withUseZabbixValueMapping(value=true): { options+: { useZabbixValueMapping: value } },
+    },
+  withProxy(value): { proxy: value },
+  withProxyMixin(value): { proxy+: value },
+  proxy+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { proxy+: { filter: value } },
+    },
+  '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: 'Specify the query flavor TODO make this required and give it a default' } },
+  withQueryType(value): { queryType: value },
+  '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: 'A unique identifier for the query within the list of targets. In server side expressions, the refId is used as a variable name to identify results. By default, the UI will assign A->Z; however setting meaningful names may be useful.' } },
+  withRefId(value): { refId: value },
+  '#withSchema': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['number'] }], help: '' } },
+  withSchema(value): { schema: value },
+  '#withShowProblems': { 'function': { args: [{ default: null, enums: ['problems', 'recent', 'history'], name: 'value', type: ['string'] }], help: '' } },
+  withShowProblems(value): { showProblems: value },
+  '#withSlaFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withSlaFilter(value): { slaFilter: value },
+  '#withSlaInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withSlaInterval(value): { slaInterval: value },
+  '#withSlaProperty': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withSlaProperty(value): { slaProperty: value },
+  withTags(value): { tags: value },
+  withTagsMixin(value): { tags+: value },
+  tags+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { tags+: { filter: value } },
+    },
+  '#withTextFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+  withTextFilter(value): { textFilter: value },
+  withTrigger(value): { trigger: value },
+  withTriggerMixin(value): { trigger+: value },
+  trigger+:
+    {
+      '#withFilter': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['string'] }], help: '' } },
+      withFilter(value): { trigger+: { filter: value } },
+    },
+  withTriggers(value): { triggers: value },
+  withTriggersMixin(value): { triggers+: value },
+  triggers+:
+    {
+      '#withAcknowledged': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['number'] }], help: '' } },
+      withAcknowledged(value): { triggers+: { acknowledged: value } },
+      '#withCount': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+      withCount(value=true): { triggers+: { count: value } },
+      '#withMinSeverity': { 'function': { args: [{ default: null, enums: null, name: 'value', type: ['number'] }], help: '' } },
+      withMinSeverity(value): { triggers+: { minSeverity: value } },
+    },
+  '#withUseCaptureGroups': { 'function': { args: [{ default: true, enums: null, name: 'value', type: ['boolean'] }], help: '' } },
+  withUseCaptureGroups(value=true): { useCaptureGroups: value },
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/grafonnet/issues/149

In the Grafonnet community some folks asked for support on the Zabbix plugin. I'm taking the liberty to propose adding this to the repo but feel free to point me in another direction.

This PR generates a library from the Typescript type `ZabbixMetricsQuery`, I'm boldly assuming that this is the type representing the JSON that is visible in the Dashboard JSON. Note that anything in `jsonnet/zabbix-query-libsonnet/` is generated by the Makefile targets.