### PR TITLE
handle changed postgres-plugin-id

### DIFF
--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -28,7 +28,8 @@ import {
 import { Divider } from './Divider';
 import { css } from '@emotion/css';
 
-const SUPPORTED_SQL_DS = ['mysql', 'postgres', 'influxdb'];
+// the postgres-plugin changed it's id, so we list both the old name and the new name
+const SUPPORTED_SQL_DS = ['mysql', 'grafana-postgresql-datasource', 'postgres', 'influxdb'];
 
 const authOptions: Array<SelectableValue<ZabbixAuthType>> = [
   { label: 'User and password', value: ZabbixAuthType.UserLogin },

--- a/src/datasource/zabbix/connectors/sql/sqlConnector.ts
+++ b/src/datasource/zabbix/connectors/sql/sqlConnector.ts
@@ -12,7 +12,8 @@ import dbConnector, {
 
 const supportedDatabases = {
   mysql: 'mysql',
-  postgres: 'postgres',
+  postgresOld: 'postgres',
+  postgresNew: 'grafana-postgresql-datasource',
 };
 
 export class SQLConnector extends DBConnector {
@@ -31,7 +32,10 @@ export class SQLConnector extends DBConnector {
   }
 
   loadSQLDialect() {
-    if (this.datasourceTypeId === supportedDatabases.postgres) {
+    if (
+      this.datasourceTypeId === supportedDatabases.postgresOld ||
+      this.datasourceTypeId === supportedDatabases.postgresNew
+    ) {
       this.sqlDialect = postgres;
     } else {
       this.sqlDialect = mysql;


### PR DESCRIPTION
fixes https://github.com/grafana/grafana-zabbix/issues/1764

the plugin-id for the postgres-datasource-plugin changed between 10.2.2 and 10.2.3:
- in 10.2.2: it is `postgres`
- in 10.2.3: it is `grafana-postgresql-datasource`

the PR changes the code so that we accept both possible ids.