### PR TITLE
Fix: Problems panel failing for versions before 7.0.0

### DIFF
--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
@@ -2,8 +2,13 @@ import { ZabbixAPIConnector } from './zabbixAPIConnector';
 
 describe('Zabbix API connector', () => {
   describe('getProxies function', () => {
+    beforeAll(() => {
+      jest.spyOn(ZabbixAPIConnector.prototype, 'initVersion').mockResolvedValue('');
+    });
+
     it('should send the name parameter to the request when version is 7 or greater for the getProxies', async () => {
-      const zabbixAPIConnector = new ZabbixAPIConnector(true, true, 123, '7.0.0');
+      const zabbixAPIConnector = new ZabbixAPIConnector(true, true, 123);
+      zabbixAPIConnector.version = '7.0.0';
       zabbixAPIConnector.request = jest.fn();
 
       await zabbixAPIConnector.getProxies();
@@ -11,7 +16,8 @@ describe('Zabbix API connector', () => {
     });
 
     it('should send the host parameter when version is less than 7.0.0', () => {
-      const zabbixAPIConnector = new ZabbixAPIConnector(true, true, 123, '6.0.0');
+      const zabbixAPIConnector = new ZabbixAPIConnector(true, true, 123);
+      zabbixAPIConnector.version = '6.0.0';
       zabbixAPIConnector.request = jest.fn();
 
       zabbixAPIConnector.getProxies();

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
@@ -1,0 +1,21 @@
+import { ZabbixAPIConnector } from './zabbixAPIConnector';
+
+describe('Zabbix API connector', () => {
+  describe('getProxies function', () => {
+    it('should send the name parameter to the request when version is 7 or greater for the getProxies', async () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector(true, true, 123, '7.0.0');
+      zabbixAPIConnector.request = jest.fn();
+
+      await zabbixAPIConnector.getProxies();
+      expect(zabbixAPIConnector.request).toHaveBeenCalledWith('proxy.get', { output: ['proxyid', 'name'] });
+    });
+
+    it('should send the host parameter when version is less than 7.0.0', () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector(true, true, 123, '6.0.0');
+      zabbixAPIConnector.request = jest.fn();
+
+      zabbixAPIConnector.getProxies();
+      expect(zabbixAPIConnector.request).toHaveBeenCalledWith('proxy.get', { output: ['proxyid', 'host'] });
+    });
+  });
+});

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -548,7 +548,7 @@ export class ZabbixAPIConnector {
     };
 
     // Before version 7.0.0 proxy_hostid was used, after - proxyid
-    if (semver.lte(this.version, '7.0.0')) {
+    if (semver.lt(this.version, '7.0.0')) {
       params.selectHosts.push('proxy_hostid');
     } else {
       params.selectHosts.push('proxyid');
@@ -582,7 +582,7 @@ export class ZabbixAPIConnector {
     };
 
     // Before version 7.0.0 proxy_hostid was used, after - proxyid
-    if (semver.lte(this.version, '7.0.0')) {
+    if (semver.lt(this.version, '7.0.0')) {
       params.selectHosts.push('proxy_hostid');
     } else {
       params.selectHosts.push('proxyid');
@@ -877,10 +877,10 @@ export class ZabbixAPIConnector {
     const params = {
       output: ['proxyid'],
     };
-    if (semver.lte(this.version, '7.0.0')) {
-      params.output.push('name');
-    } else {
+    if (semver.lt(this.version, '7.0.0')) {
       params.output.push('host');
+    } else {
+      params.output.push('name');
     }
 
     return this.request('proxy.get', params);

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -28,7 +28,7 @@ export class ZabbixAPIConnector {
   getVersionPromise: Promise<string>;
   datasourceId: number;
 
-  constructor(basicAuth: any, withCredentials: boolean, datasourceId: number, zabbixVersion?: string) {
+  constructor(basicAuth: any, withCredentials: boolean, datasourceId: number) {
     this.datasourceId = datasourceId;
     this.backendAPIUrl = `/api/datasources/${this.datasourceId}/resources/zabbix-api`;
 
@@ -36,8 +36,6 @@ export class ZabbixAPIConnector {
       basicAuth: basicAuth,
       withCredentials: withCredentials,
     };
-
-    this.version = zabbixVersion || null;
 
     this.getTrend = this.getTrend_ZBXNEXT1193;
     //getTrend = getTrend_30;

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -28,7 +28,7 @@ export class ZabbixAPIConnector {
   getVersionPromise: Promise<string>;
   datasourceId: number;
 
-  constructor(basicAuth: any, withCredentials: boolean, datasourceId: number) {
+  constructor(basicAuth: any, withCredentials: boolean, datasourceId: number, zabbixVersion?: string) {
     this.datasourceId = datasourceId;
     this.backendAPIUrl = `/api/datasources/${this.datasourceId}/resources/zabbix-api`;
 
@@ -36,6 +36,8 @@ export class ZabbixAPIConnector {
       basicAuth: basicAuth,
       withCredentials: withCredentials,
     };
+
+    this.version = zabbixVersion || null;
 
     this.getTrend = this.getTrend_ZBXNEXT1193;
     //getTrend = getTrend_30;
@@ -877,6 +879,7 @@ export class ZabbixAPIConnector {
     const params = {
       output: ['proxyid'],
     };
+    // Before version 7.0.0 host was used, after - name
     if (semver.lt(this.version, '7.0.0')) {
       params.output.push('host');
     } else {


### PR DESCRIPTION
I messed up the version comparison. lte means less then or equal. In the `getProxies` function I was even used it wrongly as `name` is only supported in version 7 and above.

How to test:

spin up devenv70 and devenv62.
open explore with problems query.

Fixes #1837