### PR TITLE
Add nested plugin paths to includes

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -55,11 +55,13 @@
   "includes": [
     {
       "type": "datasource",
-      "name": "Zabbix data source"
+      "name": "Zabbix data source",
+      "path": "datasource/plugin.json"
     },
     {
       "type": "panel",
-      "name": "Problems panel"
+      "name": "Problems panel",
+      "path": "panel-triggers/plugin.json"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
This is required so that we can serve Zabbix on the plugin CDN