### PR TITLE
services setAlias experiments

### DIFF
--- a/src/datasource/dataProcessor.ts
+++ b/src/datasource/dataProcessor.ts
@@ -13,7 +13,9 @@ function setAlias(alias: string, frame: DataFrame) {
       valueField.config.displayNameFromDS = alias;
     }
     frame.name = alias;
-    return frame;
+    if (valueField) {
+      return frame;
+    }
   }
 
   for (let fieldIndex = 0; fieldIndex < frame.fields.length; fieldIndex++) {

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -511,7 +511,12 @@ export class ZabbixDatasource extends DataSourceApi<ZabbixMetricsQuery, ZabbixDS
       const slaFilter = this.replaceTemplateVars(target.slaFilter, request.scopedVars);
       const slas = await this.zabbix.getSLAs(slaFilter);
       const result = await this.zabbix.getSLI(itservices, slas, timeRange, target, request);
-      return result;
+
+      const frame = result;
+      frame.refId = target.refId;
+      const resp = { data: [frame] };
+      this.applyFrontendFunctions(resp, request);
+      return resp.data;
     }
     const itservicesdp = await this.zabbix.getSLA(itservices, timeRange, target, request);
     const backendRequest = responseHandler.itServiceResponseToTimeSeries(itservicesdp, target.slaInterval);


### PR DESCRIPTION
when you use query_type=metrics, and add the `function` `setAlias($__zbx_host_name: abcd)`, this will work.
when you do the same for query_type=services, it does not work.

based on some investigation it seems it will not be easy to make it work for `query_type=services`.

for `query_type=metrics` this works, because this is executed as a backend-query, and that handler eventually reaches this line:
https://github.com/grafana/grafana-zabbix/blob/62a292d12eeba78f9bacf32b4faad80f3b7a5dc4/src/datasource/datasource.ts#L214,

and `applyFrontendFunctions` calls `setAlias`.

when query_type=services, it is not a backend query, so the same code is not called.
instead, we call https://github.com/grafana/grafana-zabbix/blob/62a292d12eeba78f9bacf32b4faad80f3b7a5dc4/src/datasource/datasource.ts#L488 , and that codepath does not call `applyFrontendFunctions`.

in this draft PR, i tried some quick hacks to make things work, you can see i added the `applyFrontendFunctions` call in `datasource.ts`.

this will cause `setAlias` to be called.

but that is not enough.
in `setAlias`, there is a main `IF`, which branches based on the field-count, if it's 2 or less, it goes into the first branch. we fall here, but the code looks for a field named `Value`, which it does not find. so it sets the frame-name and that's all.
my second hack adjusts this, where, if the value-field is not found, it lets the code continue. and this will finally apply the `alias`.

but that is not enough.
you see, the "happy path", when it works for `query_type=metrics`, works because of this line: https://github.com/grafana/grafana-zabbix/blob/62a292d12eeba78f9bacf32b4faad80f3b7a5dc4/src/datasource/dataProcessor.ts#L10 ... it will use the dataframe field's `valueField.config.custom.scopedVars`, so that it has access to variables. this way, when you do `setAlias($__zbx_host_name...)`, the value for `zbx_host_name` is found there (probably, i'm guessing 😁 ). but in our case, there is no such attribute, so while something like `setAlias(abcd)`, will work, `setAlias($__zbx_host_name)` will not, because it's unable to find that variable's value.