### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 750
+          # start from the oldest issues/PRs when performing stale operations
+          ascending: true
+          days-before-issue-stale: 730
+          days-before-issue-close: 60
+          stale-issue-label: stale
+          exempt-issue-labels: no stalebot,type/epic,type/bug
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last 2 years. It will be closed in 60 days if no further activity occurs. Please
+            feel free to leave a comment if you believe the issue is still relevant.
+            Thank you for your contributions!
+          close-issue-message: >
+            This issue has been automatically closed because it has not had any further
+            activity in the last 60 days. Thank you for your contributions!
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: no stalebot
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            activity in the last 60 days. It will be closed in 2 weeks if no further activity occurs. Please
+            feel free to give a status update or ping for review. Thank you for your contributions!
+          close-pr-message: >
+            This pull request has been automatically closed because it has not had any further
+            activity in the last 2 weeks. Thank you for your contributions!


### PR DESCRIPTION
This PR adds stale workflow as this repository has a lot of old issues, where we are not certain these are still relevant (some of them are 6+ years old). We've set it up with large time windows (double what we have in grafana/grafana). 

For issues:
- we mark issue as stale if no activity in the last 2 years
- we close the issue if no further activity in 2 months

For PRs:
- we mark issue as stale if no activity in the last 60 days
- we close the issue if no further activity in 2 weeks

The automation won't happen for issues/PRs with following labels `no stalebot,type/epic,type/bug`