### PR TITLE
Release 4.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [4.5.5] - 2024-09-30
+
+- Chore: Bump dompurify from 3.1.0 to 3.1.6
+- Chore: Bump grafana-plugin-sdk-go from 0.250.0 to 0.251.0
+- Chore: Bump grafana-plugin-sdk-go from 0.247.0 to 0.250.0
+
 ## [4.5.4] - 2024-09-12
 
 - Chore: Bump path-to-regexp from 1.8.0 to 1.9.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {


### PR DESCRIPTION
This pull request includes updates to the dompurify and grafana-plugin-sdk-go versions. The dompurify version has been bumped from 3.1.0 to 3.1.6, and the grafana-plugin-sdk-go version has been bumped from 0.250.0 to 0.251.0. Additionally, there is a bump in the grafana-plugin-sdk-go version from 0.247.0 to 0.250.0. These updates ensure that the plugin is using the latest versions of these dependencies.