### PR TITLE
Bug: Fix `AlertList` styling

### DIFF
--- a/src/styles/_panel-triggers.scss
+++ b/src/styles/_panel-triggers.scss
@@ -1,3 +1,41 @@
+.alert-rule-list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  list-style-type: none;
+}
+.alert-rule-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  background: $card-background;
+  box-shadow: $card-shadow;
+  padding: 4px 8px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}
+.alert-rule-item__icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  padding: 0 4px 0 2px;
+  .icon-gf,
+  .fa {
+    font-size: 200%;
+    position: relative;
+    top: 2px;
+  }
+}
+.alert-list__btn {
+  margin: 0 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .triggers-panel-scroll {
   overflow: auto;
 }


### PR DESCRIPTION
- as part of https://github.com/grafana/grafana/pull/90224, i removed these SCSS styles from core grafana
  - unfortunately the dashboard i was using to see which plugins were using which styles never flagged this plugin as using them 😭
  - still need to dig into how and why these usages weren't shown
- copy these styles into the plugin where they can be controlled and adjusted at your leisure 😄 

thanks to @PedroRibas13 @mplm17 for raising this 🙇 

Fixes https://github.com/grafana/grafana-zabbix/issues/1868
