### PR TITLE
Simplifies authentication

### DIFF
--- a/pkg/zabbix/zabbix.go
+++ b/pkg/zabbix/zabbix.go
@@ -141,11 +141,20 @@ func (zabbix *Zabbix) Authenticate(ctx context.Context) error {
 		zabbixPassword = jsonData.Get("password").MustString()
 	}
 
-	err = zabbix.api.Authenticate(ctx, zabbixLogin, zabbixPassword)
+	var auth string
+
+	if zabbix.version >= 54 {
+		auth, err = zabbix.api.Login(ctx, zabbixLogin, zabbixPassword)
+	} else {
+		auth, err = zabbix.api.LoginDeprecated(ctx, zabbixLogin, zabbixPassword)
+	}
+
 	if err != nil {
 		zabbix.logger.Error("Zabbix authentication error", "error", err)
 		return err
 	}
+
+	zabbix.api.SetAuth(auth)
 	zabbix.logger.Debug("Successfully authenticated", "url", zabbix.api.GetUrl().String(), "user", zabbixLogin)
 
 	return nil

--- a/pkg/zabbixapi/zabbix_api_test.go
+++ b/pkg/zabbixapi/zabbix_api_test.go
@@ -17,7 +17,9 @@ func TestZabbixAPIUnauthenticatedQuery(t *testing.T) {
 
 func TestLogin(t *testing.T) {
 	zabbixApi, _ := MockZabbixAPI(`{"result":"secretauth"}`, 200)
-	err := zabbixApi.Authenticate(context.Background(), "user", "password")
+	auth, err := zabbixApi.Login(context.Background(), "user", "password")
+
+	zabbixApi.SetAuth(auth)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "secretauth", zabbixApi.auth)


### PR DESCRIPTION
- Remove the `Authenticate` and `isDeprecatedUserParamError` methods
- Using the Zabbix API version to determine the use of `Login` or `LoginDeprecated`
- This will prevent errors login in old Zabbix 3 as reported in #1616

