### PR TITLE
Fix error source for invalid or missing authentication token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.5.8] - 2024-12-05
+
+- Chore: Fix error source for invalid or missing authentication token
+
 ## [4.5.7] - 2024-10-30
 
 - Chore: Bump uplot to 1.6.31

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "4.5.7",
+  "version": "4.5.8",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {

--- a/pkg/zabbix/zabbix.go
+++ b/pkg/zabbix/zabbix.go
@@ -121,12 +121,12 @@ func (zabbix *Zabbix) Authenticate(ctx context.Context) error {
 	if authType == settings.AuthTypeToken {
 		token, exists := zabbix.dsInfo.DecryptedSecureJSONData["apiToken"]
 		if !exists {
-			return errors.New("cannot find Zabbix API token")
+			return backend.DownstreamError(errors.New("cannot find Zabbix API token"))
 		}
 		err = zabbix.api.AuthenticateWithToken(ctx, token)
 		if err != nil {
 			zabbix.logger.Error("Zabbix authentication error", "error", err)
-			return err
+			return backend.DownstreamError(err)
 		}
 		zabbix.logger.Debug("Using API token for authentication")
 		return nil


### PR DESCRIPTION
Fixes https://github.com/grafana/data-sources/issues/251 and creates a patch release.

It makes following errors downstream:
- missing token
- authentication error when using token

