### PR TITLE
Fix querying and authentication for Zabbix v7.2.0+

### DIFF
--- a/devenv/zabbix72/bootstrap/Dockerfile
+++ b/devenv/zabbix72/bootstrap/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim-bullseye
+
+ENV ZBX_API_URL=http://zabbix-web:8080
+ENV ZBX_API_USER="Admin"
+ENV ZBX_API_PASSWORD="zabbix"
+ENV ZBX_CONFIG="zbx_export_hosts.json"
+ENV ZBX_BOOTSTRAP_SCRIPT="bootstrap_config.py"
+
+RUN pip install zabbix_utils
+
+ADD ./bootstrap_config.py /bootstrap_config.py
+ADD ${ZBX_CONFIG} /${ZBX_CONFIG}
+
+WORKDIR /
+
+# Run bootstrap_config.py when the container launches
+CMD ["python", "/bootstrap_config.py"]

--- a/devenv/zabbix72/bootstrap/bootstrap_config.py
+++ b/devenv/zabbix72/bootstrap/bootstrap_config.py
@@ -1,0 +1,75 @@
+import os
+from zabbix_utils import ZabbixAPI
+
+zabbix_url = os.environ['ZBX_API_URL']
+zabbix_user = os.environ['ZBX_API_USER']
+zabbix_password = os.environ['ZBX_API_PASSWORD']
+print(zabbix_url, zabbix_user, zabbix_password)
+
+zapi = ZabbixAPI(zabbix_url)
+
+for i in range(10):
+  try:
+    zapi.login(user=zabbix_user, password=zabbix_password)
+    print("Connected to Zabbix API Version %s" % zapi.api_version())
+    break
+  except Exception as e:
+    print(e)
+
+config_path = os.environ['ZBX_CONFIG']
+import_rules = {
+  'discoveryRules': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'graphs': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'host_groups': {
+      'createMissing': True
+  },
+  'hosts': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'images': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'items': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'maps': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'templateLinkage': {
+      'createMissing': True,
+  },
+  'templates': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'triggers': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+}
+
+print("Importing Zabbix config from %s" % config_path)
+with open(config_path, 'r') as f:
+  config = f.read()
+
+  try:
+    import_result = zapi.configuration.import_(source=config, format="json", rules=import_rules)
+    if import_result == True:
+      print("Zabbix config imported successfully")
+    else:
+      print("Failed to import Zabbix config")      
+  except Exception as e:
+    print(e)
+
+for h in zapi.host.get(output="extend"):
+    print(h['name'])

--- a/devenv/zabbix72/bootstrap/zbx_export_hosts.json
+++ b/devenv/zabbix72/bootstrap/zbx_export_hosts.json
@@ -1,0 +1,427 @@
+{
+  "zabbix_export": {
+    "version": "7.0",
+    "host_groups": [
+      {
+        "uuid": "2e427c268ac1468b9add94b65e2d6c14",
+        "name": "Backend"
+      },
+      {
+        "uuid": "d97ba66b283544339628b71975a6e68d",
+        "name": "Frontend"
+      },
+      {
+        "uuid": "dc579cd7a1a34222933f24f52a68bcd8",
+        "name": "Linux servers"
+      },
+      {
+        "uuid": "6f6799aa69e844b4b3918f779f2abf08",
+        "name": "Zabbix servers"
+      }
+    ],
+    "hosts": [
+      {
+        "host": "backend01",
+        "name": "backend01",
+        "templates": [
+          {
+            "name": "Template ZAS Agent"
+          }
+        ],
+        "groups": [
+          {
+            "name": "Backend"
+          },
+          {
+            "name": "Linux servers"
+          }
+        ],
+        "interfaces": [
+          {
+            "useip": "NO",
+            "dns": "zas_backend_01",
+            "interface_ref": "if1"
+          }
+        ],
+        "tags": [
+          {
+            "tag": "backend"
+          },
+          {
+            "tag": "service",
+            "value": "backend"
+          }
+        ],
+        "inventory_mode": "DISABLED"
+      },
+      {
+        "host": "backend02",
+        "name": "backend02",
+        "templates": [
+          {
+            "name": "Template ZAS Agent"
+          }
+        ],
+        "groups": [
+          {
+            "name": "Backend"
+          },
+          {
+            "name": "Linux servers"
+          }
+        ],
+        "interfaces": [
+          {
+            "useip": "NO",
+            "dns": "zas_backend_02",
+            "interface_ref": "if1"
+          }
+        ],
+        "tags": [
+          {
+            "tag": "backend"
+          },
+          {
+            "tag": "service",
+            "value": "backend"
+          }
+        ],
+        "inventory_mode": "DISABLED"
+      },
+      {
+        "host": "frontend01",
+        "name": "frontend01",
+        "templates": [
+          {
+            "name": "Template ZAS Agent"
+          }
+        ],
+        "groups": [
+          {
+            "name": "Frontend"
+          },
+          {
+            "name": "Linux servers"
+          }
+        ],
+        "interfaces": [
+          {
+            "useip": "NO",
+            "dns": "zas_frontend_01",
+            "interface_ref": "if1"
+          }
+        ],
+        "tags": [
+          {
+            "tag": "frontend"
+          },
+          {
+            "tag": "service",
+            "value": "frontend"
+          }
+        ],
+        "inventory_mode": "DISABLED"
+      },
+      {
+        "host": "frontend02",
+        "name": "frontend02",
+        "templates": [
+          {
+            "name": "Template ZAS Agent"
+          }
+        ],
+        "groups": [
+          {
+            "name": "Frontend"
+          },
+          {
+            "name": "Linux servers"
+          }
+        ],
+        "interfaces": [
+          {
+            "useip": "NO",
+            "dns": "zas_frontend_02",
+            "interface_ref": "if1"
+          }
+        ],
+        "tags": [
+          {
+            "tag": "frontend"
+          },
+          {
+            "tag": "service",
+            "value": "frontend"
+          }
+        ],
+        "inventory_mode": "DISABLED"
+      },
+      {
+        "host": "Zabbix server",
+        "name": "Zabbix server",
+        "templates": [
+          {
+            "name": "Linux by Zabbix agent"
+          },
+          {
+            "name": "Zabbix server health"
+          }
+        ],
+        "groups": [
+          {
+            "name": "Zabbix servers"
+          }
+        ],
+        "interfaces": [
+          {
+            "useip": "NO",
+            "dns": "zabbix-agent",
+            "interface_ref": "if1"
+          }
+        ],
+        "inventory_mode": "DISABLED"
+      }
+    ],
+    "template_groups": [
+      {
+        "uuid": "7df96b18c230490a9a0a9e2307226338",
+        "name": "Templates"
+      }
+    ],
+    "templates": [
+      {
+        "uuid": "2d7a65bb369c48199361913b223b1695",
+        "template": "Template ZAS Agent",
+        "name": "Template ZAS Agent",
+        "templates": [
+          {
+            "name": "Zabbix agent"
+          }
+        ],
+        "groups": [
+          {
+            "name": "Templates"
+          }
+        ],
+        "items": [
+          {
+            "uuid": "e79d4215ec014b74923b905bb8f82410",
+            "name": "Incoming network traffic on eth0",
+            "key": "net.if.in[eth0]",
+            "history": "1d",
+            "units": "bps",
+            "tags": [
+              {
+                "tag": "Application",
+                "value": "Network interfaces"
+              }
+            ]
+          },
+          {
+            "uuid": "18b377dae9fe48d093c16ee7a7c93320",
+            "name": "Outgoing network traffic on eth0",
+            "key": "net.if.out[eth0]",
+            "history": "1d",
+            "units": "bps",
+            "tags": [
+              {
+                "tag": "Application",
+                "value": "Network interfaces"
+              }
+            ]
+          },
+          {
+            "uuid": "2479e055e91c476f9be93b5f363cfa2f",
+            "name": "Processor load (1 min average per core)",
+            "key": "system.cpu.load[percpu,avg1]",
+            "history": "1d",
+            "value_type": "FLOAT",
+            "description": "The processor load is calculated as system CPU load divided by number of CPU cores.",
+            "tags": [
+              {
+                "tag": "Application",
+                "value": "CPU"
+              },
+              {
+                "tag": "Application",
+                "value": "Performance"
+              }
+            ],
+            "triggers": [
+              {
+                "uuid": "60e5484b60ca4061b21bd23f8364bd6e",
+                "expression": "last(/Template ZAS Agent/system.cpu.load[percpu,avg1])>2",
+                "name": "Processor load is too high on {HOST.NAME}",
+                "priority": "WARNING",
+                "tags": [
+                  {
+                    "tag": "app",
+                    "value": "performance"
+                  },
+                  {
+                    "tag": "type",
+                    "value": "cpu"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "uuid": "f0dd4221793c49889cf2789806afa597",
+            "name": "Processor load (15 min average per core)",
+            "key": "system.cpu.load[percpu,avg15]",
+            "history": "1d",
+            "value_type": "FLOAT",
+            "description": "The processor load is calculated as system CPU load divided by number of CPU cores.",
+            "tags": [
+              {
+                "tag": "Application",
+                "value": "CPU"
+              },
+              {
+                "tag": "Application",
+                "value": "Performance"
+              }
+            ]
+          },
+          {
+            "uuid": "9a8b4a1f173b4f209723d820dc2e054a",
+            "name": "CPU $2 time",
+            "key": "system.cpu.util[,iowait]",
+            "history": "1d",
+            "value_type": "FLOAT",
+            "units": "%",
+            "description": "Amount of time the CPU has been waiting for I/O to complete.",
+            "tags": [
+              {
+                "tag": "Application",
+                "value": "CPU"
+              },
+              {
+                "tag": "Application",
+                "value": "Performance"
+              }
+            ],
+            "triggers": [
+              {
+                "uuid": "ceb468b9eb434fa6bd4c8a5d7507fd87",
+                "expression": "avg(/Template ZAS Agent/system.cpu.util[,iowait],5m)>20",
+                "name": "Disk I/O is overloaded on {HOST.NAME}",
+                "priority": "WARNING",
+                "description": "OS spends significant time waiting for I/O (input/output) operations. It could be indicator of performance issues with storage system.",
+                "tags": [
+                  {
+                    "tag": "disk"
+                  },
+                  {
+                    "tag": "type",
+                    "value": "disk"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "uuid": "e6d19d47cf60452ead1e791da2d5c0dc",
+            "name": "CPU $2 time",
+            "key": "system.cpu.util[,system]",
+            "history": "1d",
+            "value_type": "FLOAT",
+            "units": "%",
+            "description": "The time the CPU has spent running the kernel and its processes.",
+            "tags": [
+              {
+                "tag": "Application",
+                "value": "CPU"
+              },
+              {
+                "tag": "Application",
+                "value": "Performance"
+              }
+            ]
+          },
+          {
+            "uuid": "2d81fbc139774306959712a627c99b9a",
+            "name": "CPU $2 time",
+            "key": "system.cpu.util[,user]",
+            "history": "1d",
+            "value_type": "FLOAT",
+            "units": "%",
+            "description": "The time the CPU has spent running users' processes that are not niced.",
+            "tags": [
+              {
+                "tag": "Application",
+                "value": "CPU"
+              },
+              {
+                "tag": "Application",
+                "value": "Performance"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "graphs": [
+      {
+        "uuid": "7aac0ec0c0e04b7a8bb6472d1faa7a09",
+        "name": "CPU load",
+        "ymin_type_1": "FIXED",
+        "graph_items": [
+          {
+            "color": "009900",
+            "item": {
+              "host": "Template ZAS Agent",
+              "key": "system.cpu.load[percpu,avg1]"
+            }
+          },
+          {
+            "sortorder": "2",
+            "color": "990000",
+            "item": {
+              "host": "Template ZAS Agent",
+              "key": "system.cpu.load[percpu,avg15]"
+            }
+          }
+        ]
+      },
+      {
+        "uuid": "f25064d88b964a678fac7ea6095b238a",
+        "name": "CPU utilization",
+        "show_triggers": "NO",
+        "type": "STACKED",
+        "ymin_type_1": "FIXED",
+        "ymax_type_1": "FIXED",
+        "graph_items": [
+          {
+            "sortorder": "4",
+            "drawtype": "FILLED_REGION",
+            "color": "999900",
+            "item": {
+              "host": "Template ZAS Agent",
+              "key": "system.cpu.util[,iowait]"
+            }
+          },
+          {
+            "sortorder": "5",
+            "drawtype": "FILLED_REGION",
+            "color": "990000",
+            "item": {
+              "host": "Template ZAS Agent",
+              "key": "system.cpu.util[,system]"
+            }
+          },
+          {
+            "sortorder": "6",
+            "drawtype": "FILLED_REGION",
+            "color": "000099",
+            "item": {
+              "host": "Template ZAS Agent",
+              "key": "system.cpu.util[,user]"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/devenv/zabbix72/bootstrap/zbx_export_hosts.xml
+++ b/devenv/zabbix72/bootstrap/zbx_export_hosts.xml
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>6.2</version>
+    <date>2022-04-28T13:04:18Z</date>
+    <host_groups>
+        <host_group>
+            <uuid>2e427c268ac1468b9add94b65e2d6c14</uuid>
+            <name>Backend</name>
+        </host_group>
+        <host_group>
+            <uuid>d97ba66b283544339628b71975a6e68d</uuid>
+            <name>Frontend</name>
+        </host_group>
+        <host_group>
+            <uuid>dc579cd7a1a34222933f24f52a68bcd8</uuid>
+            <name>Linux servers</name>
+        </host_group>
+        <host_group>
+            <uuid>6f6799aa69e844b4b3918f779f2abf08</uuid>
+            <name>Zabbix servers</name>
+        </host_group>
+        <host_group>
+            <uuid>7df96b18c230490a9a0a9e2307226338</uuid>
+            <name>Templates</name>
+        </host_group>
+    </host_groups>
+    <hosts>
+        <host>
+            <host>backend01</host>
+            <name>backend01</name>
+            <templates>
+                <template>
+                    <name>Template ZAS Agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Backend</name>
+                </group>
+                <group>
+                    <name>Linux servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zas_backend_01</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <tags>
+                <tag>
+                    <tag>backend</tag>
+                </tag>
+                <tag>
+                    <tag>service</tag>
+                    <value>backend</value>
+                </tag>
+            </tags>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+        <host>
+            <host>backend02</host>
+            <name>backend02</name>
+            <templates>
+                <template>
+                    <name>Template ZAS Agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Backend</name>
+                </group>
+                <group>
+                    <name>Linux servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zas_backend_02</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <tags>
+                <tag>
+                    <tag>backend</tag>
+                </tag>
+                <tag>
+                    <tag>service</tag>
+                    <value>backend</value>
+                </tag>
+            </tags>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+        <host>
+            <host>frontend01</host>
+            <name>frontend01</name>
+            <templates>
+                <template>
+                    <name>Template ZAS Agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Frontend</name>
+                </group>
+                <group>
+                    <name>Linux servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zas_frontend_01</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <tags>
+                <tag>
+                    <tag>frontend</tag>
+                </tag>
+                <tag>
+                    <tag>service</tag>
+                    <value>frontend</value>
+                </tag>
+            </tags>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+        <host>
+            <host>frontend02</host>
+            <name>frontend02</name>
+            <templates>
+                <template>
+                    <name>Template ZAS Agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Frontend</name>
+                </group>
+                <group>
+                    <name>Linux servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zas_frontend_02</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <tags>
+                <tag>
+                    <tag>frontend</tag>
+                </tag>
+                <tag>
+                    <tag>service</tag>
+                    <value>frontend</value>
+                </tag>
+            </tags>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+        <host>
+            <host>Zabbix server</host>
+            <name>Zabbix server</name>
+            <templates>
+                <template>
+                    <name>Linux by Zabbix agent</name>
+                </template>
+                <template>
+                    <name>Zabbix server health</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Zabbix servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zabbix-agent</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+    </hosts>
+    <templates>
+        <template>
+            <uuid>2d7a65bb369c48199361913b223b1695</uuid>
+            <template>Template ZAS Agent</template>
+            <name>Template ZAS Agent</name>
+            <templates>
+                <template>
+                    <name>Zabbix agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Templates</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>e79d4215ec014b74923b905bb8f82410</uuid>
+                    <name>Incoming network traffic on eth0</name>
+                    <key>net.if.in[eth0]</key>
+                    <history>1d</history>
+                    <units>bps</units>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Network interfaces</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>18b377dae9fe48d093c16ee7a7c93320</uuid>
+                    <name>Outgoing network traffic on eth0</name>
+                    <key>net.if.out[eth0]</key>
+                    <history>1d</history>
+                    <units>bps</units>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Network interfaces</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>2479e055e91c476f9be93b5f363cfa2f</uuid>
+                    <name>Processor load (1 min average per core)</name>
+                    <key>system.cpu.load[percpu,avg1]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <description>The processor load is calculated as system CPU load divided by number of CPU cores.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>60e5484b60ca4061b21bd23f8364bd6e</uuid>
+                            <expression>last(/Template ZAS Agent/system.cpu.load[percpu,avg1])&gt;2</expression>
+                            <name>Processor load is too high on {HOST.NAME}</name>
+                            <priority>WARNING</priority>
+                            <tags>
+                                <tag>
+                                    <tag>app</tag>
+                                    <value>performance</value>
+                                </tag>
+                                <tag>
+                                    <tag>type</tag>
+                                    <value>cpu</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>f0dd4221793c49889cf2789806afa597</uuid>
+                    <name>Processor load (15 min average per core)</name>
+                    <key>system.cpu.load[percpu,avg15]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <description>The processor load is calculated as system CPU load divided by number of CPU cores.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>9a8b4a1f173b4f209723d820dc2e054a</uuid>
+                    <name>CPU $2 time</name>
+                    <key>system.cpu.util[,iowait]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <description>Amount of time the CPU has been waiting for I/O to complete.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>ceb468b9eb434fa6bd4c8a5d7507fd87</uuid>
+                            <expression>avg(/Template ZAS Agent/system.cpu.util[,iowait],5m)&gt;20</expression>
+                            <name>Disk I/O is overloaded on {HOST.NAME}</name>
+                            <priority>WARNING</priority>
+                            <description>OS spends significant time waiting for I/O (input/output) operations. It could be indicator of performance issues with storage system.</description>
+                            <tags>
+                                <tag>
+                                    <tag>disk</tag>
+                                </tag>
+                                <tag>
+                                    <tag>type</tag>
+                                    <value>disk</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>e6d19d47cf60452ead1e791da2d5c0dc</uuid>
+                    <name>CPU $2 time</name>
+                    <key>system.cpu.util[,system]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <description>The time the CPU has spent running the kernel and its processes.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>2d81fbc139774306959712a627c99b9a</uuid>
+                    <name>CPU $2 time</name>
+                    <key>system.cpu.util[,user]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <description>The time the CPU has spent running users' processes that are not niced.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                </item>
+            </items>
+        </template>
+    </templates>
+    <graphs>
+        <graph>
+            <uuid>7aac0ec0c0e04b7a8bb6472d1faa7a09</uuid>
+            <name>CPU load</name>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <graph_items>
+                <graph_item>
+                    <color>009900</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.load[percpu,avg1]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <color>990000</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.load[percpu,avg15]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <uuid>f25064d88b964a678fac7ea6095b238a</uuid>
+            <name>CPU utilization</name>
+            <show_triggers>NO</show_triggers>
+            <type>STACKED</type>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <ymax_type_1>FIXED</ymax_type_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>4</sortorder>
+                    <drawtype>FILLED_REGION</drawtype>
+                    <color>999900</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.util[,iowait]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>5</sortorder>
+                    <drawtype>FILLED_REGION</drawtype>
+                    <color>990000</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.util[,system]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>6</sortorder>
+                    <drawtype>FILLED_REGION</drawtype>
+                    <color>000099</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.util[,user]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+    </graphs>
+</zabbix_export>

--- a/devenv/zabbix72/docker-compose.yml
+++ b/devenv/zabbix72/docker-compose.yml
@@ -1,0 +1,118 @@
+version: '3'
+
+services:
+  # Grafana
+  # grafana:
+  #   image: grafana/grafana:10.1.2
+  #   ports:
+  #     - '3001:3000'
+  #   volumes:
+  #     - ../..:/grafana-zabbix
+  #     - ../dashboards:/devenv/dashboards
+  #     - ../grafana.ini:/etc/grafana/grafana.ini:ro
+  #     - '../datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml'
+  #     - '../dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml'
+  # Zabbix
+  zabbix-server:
+    image: zabbix/zabbix-server-pgsql:alpine-7.2-latest
+    ports:
+      - '10051:10051'
+    depends_on:
+      - database
+    environment:
+      DB_SERVER_HOST: database
+      DB_SERVER_PORT: 5432
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+      POSTGRES_DB: zabbix
+      ZBX_TIMEOUT: 10
+      ZBX_STARTPOLLERS: 10
+      ZBX_STARTPOLLERSUNREACHABLE: 5
+      ZBX_DEBUGLEVEL: 3
+
+  zabbix-web:
+    image: zabbix/zabbix-web-apache-pgsql:alpine-7.2-latest
+    ports:
+      - '8188:8080'
+    depends_on:
+      - database
+      - zabbix-server
+    environment:
+      ZBX_SERVER_HOST: zabbix-server
+      ZBX_SERVER_PORT: 10051
+      DB_SERVER_HOST: database
+      DB_SERVER_PORT: 5432
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+      POSTGRES_DB: zabbix
+
+  database:
+    image: postgres:16
+    ports:
+      - '15432:5432'
+    command: postgres -c 'max_connections=1000'
+    environment:
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+
+  zabbix-agent:
+    image: zabbix/zabbix-agent:alpine-7.2-latest
+    environment:
+      ZBX_SERVER_HOST: zabbix-server
+      ZBX_SERVER_PORT: 10051
+
+  #########################################################
+  # Bootstrap config
+  #########################################################
+
+  bootstrap:
+    build: ./bootstrap
+    environment:
+      ZBX_API_URL: http://zabbix-web:8080
+      ZBX_API_USER: Admin
+      ZBX_API_PASSWORD: zabbix
+    depends_on:
+      - database
+      - zabbix-server
+      - zabbix-web
+
+  #########################################################
+  # Fake agents
+  #########################################################
+
+  # backend
+  redis_backend:
+    image: redis:alpine
+
+  zas_backend_01:
+    build: ../zas-agent
+    volumes:
+      - ../zas-agent/conf/zas_scenario_backend.cfg:/etc/zas_scenario.cfg
+    environment:
+      REDIS_HOST: redis_backend
+    # restart: always
+
+  zas_backend_02:
+    build: ../zas-agent
+    volumes:
+      - ../zas-agent/conf/zas_scenario_backend.cfg:/etc/zas_scenario.cfg
+    environment:
+      REDIS_HOST: redis_backend
+
+  # frontend
+  redis_frontend:
+    image: redis:alpine
+
+  zas_frontend_01:
+    build: ../zas-agent
+    volumes:
+      - ../zas-agent/conf/zas_scenario_frontend.cfg:/etc/zas_scenario.cfg
+    environment:
+      REDIS_HOST: redis_frontend
+
+  zas_frontend_02:
+    build: ../zas-agent
+    volumes:
+      - ../zas-agent/conf/zas_scenario_frontend.cfg:/etc/zas_scenario.cfg
+    environment:
+      REDIS_HOST: redis_frontend

--- a/pkg/zabbix/methods.go
+++ b/pkg/zabbix/methods.go
@@ -494,7 +494,13 @@ func (ds *Zabbix) GetAllGroups(ctx context.Context) ([]Group, error) {
 	params := ZabbixAPIParams{
 		"output":     []string{"name", "groupid"},
 		"sortfield":  "name",
-		"real_hosts": true,
+	}
+
+	// Zabbix v7.2 and later removed `real_hosts` parameter and replaced it with `with_hosts`
+	if ds.version < 72 {
+		params["real_hosts"] = true
+	} else {
+		params["with_hosts"] = true
 	}
 
 	result, err := ds.Request(ctx, &ZabbixAPIRequest{Method: "hostgroup.get", Params: params})

--- a/pkg/zabbix/zabbix.go
+++ b/pkg/zabbix/zabbix.go
@@ -89,10 +89,10 @@ func (zabbix *Zabbix) request(ctx context.Context, method string, params ZabbixA
 
 	// Skip auth for methods that are not required it
 	if method == "apiinfo.version" {
-		return zabbix.api.RequestUnauthenticated(ctx, method, params)
+		return zabbix.api.RequestUnauthenticated(ctx, method, params, zabbix.version)
 	}
 
-	result, err := zabbix.api.Request(ctx, method, params)
+	result, err := zabbix.api.Request(ctx, method, params, zabbix.version)
 	notAuthorized := isNotAuthorized(err)
 	isTokenAuth := zabbix.settings.AuthType == settings.AuthTypeToken
 	if err == zabbixapi.ErrNotAuthenticated || (notAuthorized && !isTokenAuth) {
@@ -141,7 +141,7 @@ func (zabbix *Zabbix) Authenticate(ctx context.Context) error {
 		zabbixPassword = jsonData.Get("password").MustString()
 	}
 
-	err = zabbix.api.Authenticate(ctx, zabbixLogin, zabbixPassword)
+	err = zabbix.api.Authenticate(ctx, zabbixLogin, zabbixPassword, zabbix.version)
 	if err != nil {
 		zabbix.logger.Error("Zabbix authentication error", "error", err)
 		return err

--- a/pkg/zabbixapi/zabbix_api_test.go
+++ b/pkg/zabbixapi/zabbix_api_test.go
@@ -7,9 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var version = 65
+
+
 func TestZabbixAPIUnauthenticatedQuery(t *testing.T) {
 	zabbixApi, _ := MockZabbixAPI(`{"result":"sampleResult"}`, 200)
-	resp, err := zabbixApi.RequestUnauthenticated(context.Background(), "test.get", map[string]interface{}{})
+	resp, err := zabbixApi.RequestUnauthenticated(context.Background(), "test.get", map[string]interface{}{}, version)
 
 	assert.Equal(t, "sampleResult", resp.MustString())
 	assert.Nil(t, err)
@@ -17,7 +20,7 @@ func TestZabbixAPIUnauthenticatedQuery(t *testing.T) {
 
 func TestLogin(t *testing.T) {
 	zabbixApi, _ := MockZabbixAPI(`{"result":"secretauth"}`, 200)
-	err := zabbixApi.Authenticate(context.Background(), "user", "password")
+	err := zabbixApi.Authenticate(context.Background(), "user", "password", version)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "secretauth", zabbixApi.auth)
@@ -31,6 +34,7 @@ func TestZabbixAPI(t *testing.T) {
 		mockApiResponseCode int
 		expectedResult      string
 		expectedError       error
+		version 					  int
 	}{
 		{
 			name:                "Simple request",
@@ -54,7 +58,7 @@ func TestZabbixAPI(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			zabbixApi, _ := MockZabbixAPI(tt.mockApiResponse, tt.mockApiResponseCode)
 			zabbixApi.auth = tt.auth
-			resp, err := zabbixApi.Request(context.Background(), "test.get", map[string]interface{}{})
+			resp, err := zabbixApi.Request(context.Background(), "test.get", map[string]interface{}{}, version)
 
 			if tt.expectedError != nil {
 				assert.Equal(t, err, tt.expectedError)

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
@@ -23,5 +23,31 @@ describe('Zabbix API connector', () => {
       zabbixAPIConnector.getProxies();
       expect(zabbixAPIConnector.request).toHaveBeenCalledWith('proxy.get', { output: ['proxyid', 'host'] });
     });
+
+    it('should send the with_hosts parameter when version is 7.2+', () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector(true, true, 123);
+      zabbixAPIConnector.version = '7.2.0';
+      zabbixAPIConnector.request = jest.fn();
+
+      zabbixAPIConnector.getGroups();
+      expect(zabbixAPIConnector.request).toHaveBeenCalledWith('hostgroup.get', {
+        output: ['name', 'groupid'],
+        sortfield: 'name',
+        with_hosts: true,
+      });
+    });
+
+    it('should send the real_hosts parameter when version is <7.2', () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector(true, true, 123);
+      zabbixAPIConnector.version = '7.1.0';
+      zabbixAPIConnector.request = jest.fn();
+
+      zabbixAPIConnector.getGroups();
+      expect(zabbixAPIConnector.request).toHaveBeenCalledWith('hostgroup.get', {
+        output: ['name', 'groupid'],
+        sortfield: 'name',
+        real_hosts: true,
+      });
+    });
   });
 });

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -116,6 +116,10 @@ export class ZabbixAPIConnector {
     return semver.gte(this.version, '5.4.0');
   }
 
+  isZabbix72OrHigher() {
+    return semver.gte(this.version, '7.2.0');
+  }
+
   ////////////////////////////////
   // Zabbix API method wrappers //
   ////////////////////////////////
@@ -142,8 +146,14 @@ export class ZabbixAPIConnector {
     const params = {
       output: ['name', 'groupid'],
       sortfield: 'name',
-      real_hosts: true,
     };
+
+    // Zabbix v7.2 and later removed `real_hosts` parameter and replaced it with `with_hosts`
+    if (this.isZabbix72OrHigher()) {
+      params['with_hosts'] = true;
+    } else {
+      params['real_hosts'] = true;
+    }
 
     return this.request('hostgroup.get', params);
   }


### PR DESCRIPTION
In this PR, we are fixing authentication that is currently broken for Zabbix v7.2+. The reason is that in 7.0 `auth` param was deprecated in favor of `Auth` header and in 7.2 the support was removed: https://www.zabbix.com/documentation/7.0/en/manual/api#authorization-methods

Moreover, the `real_hosts` was deprecated https://www.zabbix.com/documentation/7.0/en/manual/api/reference/hostgroup/get?hl=real_hosts in favor of `with_hosts` and support was removed in in 7.2. 

This PR fixes it and also adds a new docker block for Zabbix 72 for testing.

I have tested this PR with Zabbix 7.2:

https://github.com/user-attachments/assets/ea340711-46ed-44e0-a94e-ab58454d4cf8


I have tested this PR with Zabbix 7.0:

https://github.com/user-attachments/assets/a331d947-10c9-491a-a0b3-77b23b129063


I have tested this PR with Zabbix 6.2:

https://github.com/user-attachments/assets/d050ee69-d44b-4452-9d8a-a9083e00d35b

