### PR TITLE
Fix: host groups not showing in problems panel

### DIFF
--- a/.changeset/gentle-bees-rescue.md
+++ b/.changeset/gentle-bees-rescue.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+Fix problems panel not showing host groups

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -530,7 +530,7 @@ export class ZabbixAPIConnector {
     return this.request('problem.get', params).then(utils.mustArray);
   }
 
-  getTriggersByIds(triggerids: string[]) {
+  async getTriggersByIds(triggerids: string[]) {
     const params = {
       output: 'extend',
       triggerids: triggerids,
@@ -555,10 +555,17 @@ export class ZabbixAPIConnector {
       params.selectHosts.push('proxyid');
     }
 
-    return this.request('trigger.get', params).then(utils.mustArray);
+    const triggers = await this.request('trigger.get', params);
+    // When version is 7.0.0 or higher, groups are returned as hostgroups
+    if (semver.gte(this.version, '7.0.0')) {
+      Object.keys(triggers).forEach((trigger) => {
+        triggers[trigger].groups = triggers[trigger].hostgroups;
+      });
+    }
+    return triggers;
   }
 
-  getTriggers(groupids, hostids, applicationids, options) {
+  async getTriggers(groupids, hostids, applicationids, options) {
     const { showTriggers, maintenance, timeFrom, timeTo } = options;
 
     const params: any = {
@@ -604,7 +611,14 @@ export class ZabbixAPIConnector {
       params.lastChangeTill = timeTo;
     }
 
-    return this.request('trigger.get', params);
+    const triggers = await this.request('trigger.get', params);
+    // When version is 7.0.0 or higher, groups are returned as hostgroups
+    if (semver.gte(this.version, '7.0.0')) {
+      triggers.forEach((trigger) => {
+        trigger.groups = trigger.hostgroups;
+      });
+    }
+    return triggers;
   }
 
   getEvents(objectids, timeFrom, timeTo, showEvents, limit) {
@@ -778,7 +792,14 @@ export class ZabbixAPIConnector {
       if (count) {
         triggers = triggers.length;
       }
+      // When version is 7.0.0 or higher, groups are returned as hostgroups
+      if (semver.gte(this.version, '7.0.0')) {
+        triggers.forEach((trigger) => {
+          trigger.groups = trigger.hostgroups;
+        });
+      }
     }
+
     return triggers;
   }
 
@@ -826,6 +847,12 @@ export class ZabbixAPIConnector {
         if (count) {
           triggers = triggers.length;
         }
+        // When version is 7.0.0 or higher, groups are returned as hostgroups
+        if (semver.gte(this.version, '7.0.0')) {
+          triggers.forEach((trigger) => {
+            trigger.groups = trigger.hostgroups;
+          });
+        }
       }
       return triggers;
     });
@@ -868,6 +895,12 @@ export class ZabbixAPIConnector {
         triggers = filterTriggersByAcknowledge(triggers, acknowledged);
         if (count) {
           triggers = triggers.length;
+        }
+        // When version is 7.0.0 or higher, groups are returned as hostgroups
+        if (semver.gte(this.version, '7.0.0')) {
+          triggers.forEach((trigger) => {
+            trigger.groups = trigger.hostgroups;
+          });
         }
       }
       return triggers;


### PR DESCRIPTION
This PR fixes 2 issues mentioned below.
Fixes #1943
Fixes #1946

## Problems Panel not showing host groups:

[src/panel-triggers/components/Problems/Problems.tsx](https://github.com/grafana/grafana-zabbix/blob/0355f40fc22fc0e7cb82fced61a9487745c7e640/src/panel-triggers/components/Problems/Problems.tsx)
![Image](https://github.com/user-attachments/assets/2d5d8207-dcd6-4e80-aef3-a9eadf4d3dc9)

### How to reproduce

1. Go to `Zabbix data source features` dashboard
2. Open Problems panel
3. In the panel config enable host groups field
4. Host groups should show up in the table

## Triggers not showing

![Image](https://github.com/user-attachments/assets/4319ebc1-bbdb-4648-b7d5-269e82351804)

### How to reproduce

1. Go to explore and select the zabbix ds
2. Select `Triggers` Query type
3. Add `Backend` as a group
4. Add `/.*/` as host
5. There should be 2 average triggers 
 