### PR TITLE
Use `go install` to install golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 	yarn install --pure-lockfile
 	# Backend
 	go install -v ./pkg/
-	GO111MODULE=off go get -u golang.org/x/lint/golint
+	go install golang.org/x/lint/golint@latest
 
 deps-go:
 	go install -v ./pkg/


### PR DESCRIPTION
This is the recommended approach since Go 1.17

I was getting an error when running `make install`:
```
GO111MODULE=off go get -u golang.org/x/lint/golint
go: modules disabled by GO111MODULE=off; see 'go help modules'
```