### PR TITLE
Add URL for public dashboards (Issue #1635)

### DIFF
--- a/.changeset/orange-coats-draw.md
+++ b/.changeset/orange-coats-draw.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+Alter API pathing for Datasource to query via the public api for public dashboards

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -209,11 +209,15 @@ export class ZabbixDatasource extends DataSourceApi<ZabbixMetricsQuery, ZabbixDS
       body.to = range.to.valueOf().toString();
     }
 
+    const url = config.publicDashboardAccessToken
+      ? `/api/public/dashboards/${config.publicDashboardAccessToken!}/panels/${request.panelId}/query`
+      : '/api/ds/query';
+
     let rsp: any;
     try {
       rsp = await getBackendSrv()
         .fetch({
-          url: '/api/ds/query',
+          url: url,
           method: 'POST',
           data: body,
           requestId,

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import semver from 'semver';
 import kbn from 'grafana/app/core/utils/kbn';
 import * as utils from '../../../utils';
+import config from 'grafana/app/core/config';
 import { MIN_SLA_INTERVAL, ZBX_ACK_ACTION_ADD_MESSAGE, ZBX_ACK_ACTION_NONE } from '../../../constants';
 import { ShowProblemTypes } from '../../../types/query';
 import { ZBXProblem, ZBXTrigger } from '../../../types';
@@ -41,7 +42,10 @@ export class ZabbixAPIConnector {
     this.getTrend = this.getTrend_ZBXNEXT1193;
     //getTrend = getTrend_30;
 
-    this.initVersion();
+    // Prevent pinging FORBIDDEN on public dashboard load
+    if (!config.publicDashboardAccessToken) {
+      this.initVersion();
+    }
   }
 
   //////////////////////////


### PR DESCRIPTION
This PR partially resolves issue #1635 which prevents the use of the public "shared dashboard" feature when using grafana-zabbix.

This does not resolve the issue for the Zabbix Issues panel, which heavily uses the custom API endpoint. It does however solve most usual use-cases for public dashboards with metrics.

More refactoring would be needed to resolve this for all workflows, but this can act as a stop-gap solution until then.

