### PR TITLE
Release version 5.0.3 with security updates and bug fixes

### DIFF
--- a/.changeset/four-cobras-invent.md
+++ b/.changeset/four-cobras-invent.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Security: Update golang.org/x/net from v0.35.0 to v0.37.0

--- a/.changeset/gentle-carrots-cough.md
+++ b/.changeset/gentle-carrots-cough.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Chore: Build plugin with go 1.24.1

--- a/.changeset/purple-lions-join.md
+++ b/.changeset/purple-lions-join.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Fix: Basic authentication in zabbix <7.2

--- a/.changeset/witty-eels-camp.md
+++ b/.changeset/witty-eels-camp.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Chore: Bump grafana-plugin-sdk-go from 0.270.0 to 0.274.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 5.0.3
+
+### Patch Changes
+
+🐛 Security: Update golang.org/x/net from v0.35.0 to v0.37.0
+⚙️ Chore: Build plugin with go 1.24.1
+🐛 Fix: Basic authentication in zabbix <7.2
+⚙️ Chore: Bump grafana-plugin-sdk-go from 0.270.0 to 0.274.0
+
 ## [5.0.2] - 2025-02-27
 
 - Chore: Fix error source for parsing of invalid json response

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {


### PR DESCRIPTION
- Updated golang.org/x/net from v0.35.0 to v0.37.0 for security improvements.
- Built the plugin with Go version 1.24.1.
- Fixed basic authentication issues for Zabbix versions <7.2.
- Bumped grafana-plugin-sdk-go from v0.270.0 to v0.274.0.
