### PR TITLE
Release version 5.0.4 with TLS handshake timeout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change Log
 
-## 5.0.3
+## 5.0.4
 
-### Patch Changes
+🐛 Fix: TLS handshake timeout issues by disabling post-quantum key exchange mechanism in go
+
+## 5.0.3
 
 🐛 Security: Update golang.org/x/net from v0.35.0 to v0.37.0
 ⚙️ Chore: Build plugin with go 1.24.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/alexanderzobnin/grafana-zabbix
 
 go 1.24
 
+// Go 1.24 enabled the post-quantum key exchange mechanism
+// X25519MLKEM768 by default. It can cause issues with some TLS servers
+// that do not handle large records correctly.
+// It can be disabled using the following command:
+godebug tlsmlkem=0
+
 require (
 	github.com/bitly/go-simplejson v0.5.1
 	github.com/dlclark/regexp2 v1.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {


### PR DESCRIPTION
- Addressed TLS handshake timeout issues by disabling the post-quantum key exchange mechanism in Go.
- Updated CHANGELOG to reflect the new version and changes.
