### PR TITLE
Release version 5.0.4 with a fix for TLS handshake timeout issues by …

### DIFF
--- a/.changeset/smart-pears-change.md
+++ b/.changeset/smart-pears-change.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Fix: TLS handshake timeout issues by disabling post-quantum key exchange mechanism in go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 5.0.4
+
+🐛 Fix: TLS handshake timeout issues by disabling post-quantum key exchange mechanism in go
+
 ## 5.0.3
 
 🐛 Security: Update golang.org/x/net from v0.35.0 to v0.37.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {


### PR DESCRIPTION
…disabling the post-quantum key exchange mechanism in Go.
