### PR TITLE
Remove id-token permission for compatibility workflows

### DIFF
--- a/.github/workflows/compatibility-50.yml
+++ b/.github/workflows/compatibility-50.yml
@@ -2,7 +2,6 @@ name: zabbix_50
 run-name: Compatibility with Zabbix 5.0 test
 permissions:
   contents: read
-  id-token: read
 
 on:
   push:

--- a/.github/workflows/compatibility-60.yml
+++ b/.github/workflows/compatibility-60.yml
@@ -2,7 +2,6 @@ name: zabbix_60
 run-name: Compatibility with Zabbix 6.0 test
 permissions:
   contents: read
-  id-token: read
 
 on:
   push:

--- a/.github/workflows/compatibility-70.yml
+++ b/.github/workflows/compatibility-70.yml
@@ -2,7 +2,6 @@ name: zabbix_70
 run-name: Compatibility with Zabbix 7.0 test
 permissions:
   contents: read
-  id-token: read
 
 on:
   push:

--- a/.github/workflows/compatibility-72.yml
+++ b/.github/workflows/compatibility-72.yml
@@ -2,7 +2,6 @@ name: zabbix_72
 run-name: Compatibility with Zabbix 7.2 test
 permissions:
   contents: read
-  id-token: read
 
 on:
   push:


### PR DESCRIPTION
The read value for id-token is not available. This PR fixes that.
