### PR TITLE
(IGNORE) Testing plugin-ci-workflows for forks

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@giuseppe/fork-fix
     with:
       go-version: '1.24'
       golangci-lint-version: '1.64.6'


### PR DESCRIPTION
Testing https://github.com/grafana/plugin-ci-workflows/pull/96 for external forks and (backend plugin)