### PR TITLE
Forward refID to resultant dataframe

### DIFF
--- a/src/datasource/responseHandler.spec.ts
+++ b/src/datasource/responseHandler.spec.ts
@@ -6,6 +6,7 @@ describe('convertToWide', () => {
     let frames = convertToWide([
       new MutableDataFrame({
         name: 'SLI',
+        refId: 'A',
         fields: [
           { name: TIME_SERIES_TIME_FIELD_NAME, values: [1], type: FieldType.time },
           { name: TIME_SERIES_TIME_FIELD_NAME, values: [1.1], type: FieldType.number },
@@ -13,6 +14,7 @@ describe('convertToWide', () => {
       }),
       new MutableDataFrame({
         name: 'SLI',
+        refId: 'B',
         fields: [
           { name: TIME_SERIES_TIME_FIELD_NAME, values: [1], type: FieldType.time },
           { name: TIME_SERIES_TIME_FIELD_NAME, values: [1.2], type: FieldType.number },
@@ -24,5 +26,6 @@ describe('convertToWide', () => {
     expect(frames[0].fields[0].values.at(0)).toStrictEqual(1);
     expect(frames[0].fields[1].values.at(0)).toStrictEqual(1.1);
     expect(frames[0].fields[2].values.at(0)).toStrictEqual(1.2);
+    expect(frames[0].refId).toStrictEqual('A');
   });
 });

--- a/src/datasource/responseHandler.ts
+++ b/src/datasource/responseHandler.ts
@@ -396,6 +396,7 @@ export function convertToWide(data: MutableDataFrame[]): DataFrame[] {
   }
 
   const frame: DataFrame = {
+    refId: data[maxLengthIndex].refId,
     name: 'wide',
     fields,
     length: timeField.values.length,


### PR DESCRIPTION
Fixes #1982

With a refID of `test test`
<img width="273" height="223" alt="Screenshot 2025-08-06 at 4 11 41 PM" src="https://github.com/user-attachments/assets/1c20e70d-f2d2-40e7-a494-20aa4e1c3d07" />

Before
<img width="291" height="193" alt="Screenshot 2025-08-06 at 4 18 40 PM" src="https://github.com/user-attachments/assets/b5ccb244-ac92-4929-b589-e5d01eebfad6" />

After
<img width="218" height="208" alt="Screenshot 2025-08-06 at 4 11 33 PM" src="https://github.com/user-attachments/assets/6b0049b0-6829-4599-82dd-5af001e94690" />

