### PR TITLE
Fix: slaid is missing error

### DIFF
--- a/.changeset/stupid-coats-accept.md
+++ b/.changeset/stupid-coats-accept.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+Fix: slaid is missing error

--- a/src/datasource/zabbix/zabbix.ts
+++ b/src/datasource/zabbix/zabbix.ts
@@ -670,6 +670,9 @@ export class Zabbix implements ZabbixConnector {
     }
 
     const slaIds = slas.map((s) => s.slaid);
+    if (slaIds.length === 0) {
+      return [];
+    }
     if (slaIds.length > 1) {
       const sliQueries = slaIds?.map((slaId) => this.zabbixAPI.getSLI(slaId, itServiceIds, timeRange, options));
       const results = await Promise.all(sliQueries);


### PR DESCRIPTION
In order to reproduce this you need to create a Service and an SLO. The bug appears when an SLO is not set.


Fixes #1784