### PR TITLE
fix(zabbix): do not cache service status

### DIFF
--- a/.changeset/fresh-services-refresh.md
+++ b/.changeset/fresh-services-refresh.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+Do not cache Zabbix IT Service responses, so status changes appear without waiting for the configured cache TTL.

--- a/pkg/zabbix/cache.go
+++ b/pkg/zabbix/cache.go
@@ -13,7 +13,6 @@ var cachedMethods = map[string]bool{
 	"host.get":        true,
 	"application.get": true,
 	"item.get":        true,
-	"service.get":     true,
 	"usermacro.get":   true,
 	"proxy.get":       true,
 	"valuemap.get":    true,

--- a/pkg/zabbix/zabbix_test.go
+++ b/pkg/zabbix/zabbix_test.go
@@ -82,6 +82,37 @@ func TestNonCachedQuery(t *testing.T) {
 	assert.Equal(t, "testNew", result)
 }
 
+func TestServiceQueryIsNotCached(t *testing.T) {
+	serviceCalls := 0
+	zabbixClient := NewZabbixClientWithHandler(t, func(payload ApiRequestPayload) string {
+		switch payload.Method {
+		case "apiinfo.version":
+			return `{"result":"6.4.0"}`
+		case "service.get":
+			serviceCalls++
+			if serviceCalls == 1 {
+				return `{"result":"statusOld"}`
+			}
+			return `{"result":"statusNew"}`
+		default:
+			return `{"result":null}`
+		}
+	})
+	query := &ZabbixAPIRequest{Method: "service.get", Params: emptyParams}
+
+	resp, err := zabbixClient.Request(context.Background(), query)
+	assert.NoError(t, err)
+	result, _ := resp.String()
+	assert.Equal(t, "statusOld", result)
+
+	resp, err = zabbixClient.Request(context.Background(), query)
+
+	assert.NoError(t, err)
+	result, _ = resp.String()
+	assert.Equal(t, "statusNew", result)
+	assert.Equal(t, 2, serviceCalls)
+}
+
 // TestVersionCacheDoesNotCollideWithAPIRequestCache covers a bug flagged in
 // review: the version used to be cached under a ZabbixAPIRequest key in the
 // same keyspace as regular *simplejson.Json API responses. A caller


### PR DESCRIPTION
## Summary

- remove `service.get` from the API methods cached by the backend
- add a regression test proving consecutive service queries fetch fresh status data
- add a patch changeset for the behavior change

Fixes #1891

## Testing

- `go test ./pkg/... -count=1`
- `go vet ./pkg/...`
- `go test -race ./pkg/zabbix -run ^TestServiceQueryIsNotCached$ -count=1`
- `npx --yes @changesets/cli status --since=origin/main`
- `git diff --check`

## AI assistance

This PR was prepared with assistance from OpenAI Codex. I reviewed the resulting changes and ran the tests listed above.