### PR TITLE
chore: bump dependencies for vuln fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "lodash": "4.18.1",
         "mini-css-extract-plugin": "2.10.2",
         "moment": "2.30.1",
-        "postcss": "8.5.20",
+        "postcss": "8.5.26",
         "postcss-loader": "8.2.1",
         "prettier": "3.9.5",
         "replace-in-file-webpack-plugin": "1.0.6",
@@ -14602,9 +14602,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -14622,7 +14622,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "lodash": "4.18.1",
     "mini-css-extract-plugin": "2.10.2",
     "moment": "2.30.1",
-    "postcss": "8.5.20",
+    "postcss": "8.5.26",
     "postcss-loader": "8.2.1",
     "prettier": "3.9.5",
     "replace-in-file-webpack-plugin": "1.0.6",


### PR DESCRIPTION
Addresses:
- [CVE-2026-13149](https://www.cve.org/CVERecord?id=CVE-2026-13149) brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups
- [CVE-2026-13676](https://www.cve.org/CVERecord?id=CVE-2026-13676) fast-uri: host confusion via failed IDN canonicalization
- [CVE-2026-14257](https://www.cve.org/CVERecord?id=CVE-2026-14257) brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash
- [CVE-2026-15157](https://www.cve.org/CVERecord?id=CVE-2026-15157) undici: CRLF injection via blob-like body 'type' property
- [CVE-2026-16221](https://www.cve.org/CVERecord?id=CVE-2026-16221) fast-uri: host confusion via literal backslash authority delimiter
- [CVE-2026-16728](https://www.cve.org/CVERecord?id=CVE-2026-16728) undici: downstream response desynchronization via retry interceptor
- [CVE-2026-16729](https://www.cve.org/CVERecord?id=CVE-2026-16729) undici: cookie attribute injection via unsanitized domain and unparsed setCookie fields
- [CVE-2026-18446](https://www.cve.org/CVERecord?id=CVE-2026-18446) fast-uri: host confusion via backslash authority introducer
- [CVE-2026-53550](https://www.cve.org/CVERecord?id=CVE-2026-53550) js-yaml: quadratic-complexity DoS in merge key handling via repeated aliases
- [CVE-2026-54272](https://www.cve.org/CVERecord?id=CVE-2026-54272) ip-address: misclassification of IPv4-mapped/NAT64 IPv6 addresses can bypass SSRF and trust-boundary checks
- [CVE-2026-59869](https://www.cve.org/CVERecord?id=CVE-2026-59869) js-yaml: YAML merge-key chains can force quadratic CPU consumption
- [CVE-2026-59879](https://www.cve.org/CVERecord?id=CVE-2026-59879) immutable: List 32-bit trie overflow causes unrecoverable DoS
- [CVE-2026-59880](https://www.cve.org/CVERecord?id=CVE-2026-59880) immutable: hash-collision algorithmic complexity DoS in Immutable.Map/Set
- [CVE-2026-67213](https://www.cve.org/CVERecord?id=CVE-2026-67213) nanoid: custom generators can loop indefinitely when size is zero
- [CVE-2026-69152](https://www.cve.org/CVERecord?id=CVE-2026-69152) brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation
- [CVE-2026-69153](https://www.cve.org/CVERecord?id=CVE-2026-69153) postcss: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset
- [CVE-2026-69192](https://www.cve.org/CVERecord?id=CVE-2026-69192) ip-address: Address4 decodes leading-zero octets as decimal while resolvers decode them as octal, allowing SSRF and trust-boundary bypass
- [CVE-2026-69198](https://www.cve.org/CVERecord?id=CVE-2026-69198) ip-address: a CIDR suffix on the parsed address suppresses special-use classification and can bypass SSRF and trust-boundary checks
- [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) dompurify: IN_PLACE hook removal leaves a detached subtree executable, causing XSS
- [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) js-yaml: quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported
- [CVE-2026-73566](https://www.cve.org/CVERecord?id=CVE-2026-73566) tar: uncontrolled recursion in mapHas/filesFilter allows an uncatchable stack-overflow DoS via a crafted long-path tar with member selection (no GitHub advisory range data; confirmed by version 7.5.22 >= 7.5.21)