### PR TITLE
fix(zabbix): handle unmatched item tag regex

### DIFF
--- a/src/datasource/specs/datasource.spec.ts
+++ b/src/datasource/specs/datasource.spec.ts
@@ -286,6 +286,22 @@ describe('ZabbixDatasource', () => {
     });
   });
 
+  describe('When resolving items by tag regex', () => {
+    it('returns no items without making an unfiltered request when no tags match', async () => {
+      ctx.ds.zabbix.getHosts = jest.fn().mockResolvedValue([{ hostid: '10001' }]);
+      ctx.ds.zabbix.getItemTags = jest.fn().mockResolvedValue([]);
+      ctx.ds.zabbix.zabbixAPI.getItems = jest.fn();
+
+      const result = await ctx.ds.zabbix.getAllItems('GroupFilter', 'HostFilter', 'AppFilter', '/^NonExistentTag/', {
+        itemtype: 'num',
+      });
+
+      expect(result).toEqual([]);
+      expect(ctx.ds.zabbix.getItemTags).toHaveBeenCalledWith('GroupFilter', 'HostFilter', '/^NonExistentTag/');
+      expect(ctx.ds.zabbix.zabbixAPI.getItems).not.toHaveBeenCalled();
+    });
+  });
+
   describe('When invoking metricFindQuery() with legacy query', () => {
     beforeEach(() => {
       ctx.ds.zabbix = {

--- a/src/datasource/zabbix/zabbix.ts
+++ b/src/datasource/zabbix/zabbix.ts
@@ -423,6 +423,9 @@ export class Zabbix implements ZabbixConnector {
     // Support regexp in tags
     if (utils.isRegex(itemTagFilter)) {
       const tags = await this.getItemTags(groupFilter, hostFilter, itemTagFilter);
+      if (tags.length === 0) {
+        return [];
+      }
       itemTagFilter = tags.map((t) => t.name).join(',');
     }
 


### PR DESCRIPTION
## Summary
- return no items when an item tag regex matches no tags
- prevent the frontend Direct DB path from issuing an unfiltered item request
- add regression coverage for the empty-match case

Fixes: https://github.com/grafana/grafana-zabbix/issues/2534