### PR TITLE
feat(config): redesign datasource configuration page with boxed sections and navigation sidebar

### DIFF
--- a/.changeset/loose-berries-shout.md
+++ b/.changeset/loose-berries-shout.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': minor
+---
+
+Redesign the datasource configuration page with the new Grafana config design: collapsible boxed sections (Zabbix connection, TLS/SSL, HTTP, Additional settings) with a navigation sidebar, inline field descriptions, and side-by-side fields - HTTP authentication is reduced to None/Basic, the only method the backend actually uses

--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -10,33 +10,91 @@ import {
 } from '@grafana/data';
 import {
   Alert,
+  Badge,
+  Box,
+  CollapsableSection,
   Combobox,
   ComboboxOption,
   Field,
-  Icon,
   Input,
-  Label,
   MultiSelect,
   SecretInput,
   SecureSocksProxySettings,
+  Stack,
   Switch,
-  Tooltip,
+  TagsInput,
+  Text,
+  TextLink,
   useStyles2,
 } from '@grafana/ui';
 import { ZabbixAuthType, ZabbixDSOptions, ZabbixSecureJSONData } from '../types/config';
 import { gte } from 'semver';
 import {
-  Auth,
-  ConfigSection,
   ConfigSubSection,
-  EditorStack,
   convertLegacyAuthProps,
-  ConnectionSettings,
+  CustomHeadersSettings,
   DataSourceDescription,
-  AdvancedHttpSettings,
+  TLSSettings,
 } from '@grafana/plugin-ui';
-import { Divider } from './Divider';
 import { css } from '@emotion/css';
+import { Divider } from './Divider';
+import { CONFIG_SECTION_HEADERS, LeftSidebar } from './LeftSidebar';
+
+const CONTAINER_MIN_WIDTH = '450px';
+
+// Simple sanity check for the Zabbix API URL, mirroring the validation of the
+// plugin-ui ConnectionSettings component this section replaced.
+const isValidUrl = (url: string) => /^https?:\/\/\S+$/.test(url);
+
+// Bordered, collapsible container giving each configuration section the boxed
+// look of the new Grafana datasource config design. The whole header row
+// toggles the section, optional sections carry a top-right badge, and the id
+// is the LeftSidebar scroll anchor.
+const ConfigSectionBox = ({
+  id,
+  title,
+  isOptional,
+  isInitiallyOpen = true,
+  description,
+  children,
+}: {
+  id: string;
+  title: string;
+  isOptional?: boolean;
+  isInitiallyOpen?: boolean;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+}) => {
+  const styles = useStyles2(getStyles);
+  // Controlled open state: some Grafana versions only toggle CollapsableSection
+  // when both isOpen and onToggle are provided.
+  const [isOpen, setIsOpen] = useState(isInitiallyOpen);
+  return (
+    <Box borderStyle="solid" borderColor="weak" padding={2} marginBottom={4} id={id} minWidth={CONTAINER_MIN_WIDTH}>
+      <CollapsableSection
+        label={
+          <>
+            <Text element="h3" variant="h3">
+              {title}
+            </Text>
+            {isOptional && <Badge text="optional" color="darkgrey" className={styles.optionalBadge} />}
+          </>
+        }
+        isOpen={isOpen}
+        onToggle={() => setIsOpen(!isOpen)}
+      >
+        {description && (
+          <Box marginBottom={2}>
+            <Text variant="body" color="secondary">
+              {description}
+            </Text>
+          </Box>
+        )}
+        {children}
+      </CollapsableSection>
+    </Box>
+  );
+};
 
 // the postgres-plugin changed it's id, so we list both the old name and the new name
 const SUPPORTED_SQL_DS = ['mysql', 'grafana-postgresql-datasource', 'postgres', 'influxdb'];
@@ -46,10 +104,32 @@ const authOptions: Array<ComboboxOption<ZabbixAuthType>> = [
   { label: 'API token', value: ZabbixAuthType.Token },
 ];
 
+const httpAuthOptions: Array<ComboboxOption<string>> = [
+  {
+    label: 'No Authentication',
+    value: 'none',
+    description: 'The Zabbix web server is reachable without extra credentials',
+  },
+  {
+    label: 'Basic authentication',
+    value: 'basic',
+    description: 'Authenticate against a reverse proxy in front of Zabbix with HTTP basic auth',
+  },
+];
+
+const userIdentityOptions: Array<ComboboxOption<string>> = [
+  { label: 'Username', value: 'username' },
+  { label: 'Email', value: 'email' },
+];
+
 export type Props = DataSourcePluginOptionsEditorProps<ZabbixDSOptions, ZabbixSecureJSONData>;
 export const ConfigEditor = (props: Props) => {
   const styles = useStyles2(getStyles);
   const { options, onOptionsChange } = props;
+
+  // Reuse the battle-tested option handlers of the plugin-ui Auth component
+  // for the TLS settings and HTTP basic auth fields.
+  const authProps = convertLegacyAuthProps({ config: options, onChange: onOptionsChange });
 
   // Derive selectedDBDatasource and currentDSType from options (prefer UID; fallback to id for legacy config)
   const { selectedDBDatasource, currentDSType } = useMemo(() => {
@@ -79,6 +159,33 @@ export const ConfigEditor = (props: Props) => {
   ]);
   const [canEditExcludedUsers, setCanEditExcludedUsers] = useState(true);
   const [userFetchWarning, setUserFetchWarning] = useState<string | null>(null);
+
+  // Pre-expand the optional sections on load when any setting inside them is configured
+  const [tlsSettingsOpen] = useState<boolean>(() => {
+    const { jsonData } = options;
+    return Boolean(jsonData.tlsAuth || jsonData.tlsAuthWithCACert || jsonData.tlsSkipVerify || jsonData.serverName);
+  });
+
+  const [httpSettingsOpen] = useState<boolean>(() => {
+    const { jsonData } = options;
+    return Boolean(options.basicAuth || jsonData.httpHeaderName1 || jsonData.keepCookies?.length);
+  });
+
+  const [additionalSettingsOpen] = useState<boolean>(() => {
+    const { jsonData } = options;
+    return Boolean(
+      jsonData.cacheTTL ||
+      jsonData.timeout ||
+      jsonData.queryTimeout ||
+      jsonData.trendsFrom ||
+      jsonData.trendsRange ||
+      jsonData.dbConnectionEnable ||
+      jsonData.disableReadOnlyUsersAck ||
+      jsonData.disableDataAlignment ||
+      jsonData.perUserAuth ||
+      jsonData.enableSecureSocksProxy
+    );
+  });
 
   // Fetch Grafana users on mount
   useEffect(() => {
@@ -168,430 +275,498 @@ export const ConfigEditor = (props: Props) => {
   }, []);
 
   return (
-    <>
-      <DataSourceDescription
-        dataSourceName="Zabbix"
-        docsLink="https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/configuration/"
-        hasRequiredFields={true}
-      />
+    <Stack justifyContent="space-between">
+      <div className={styles.leftSidebarWrapper}>
+        <LeftSidebar />
+      </div>
 
-      <Divider />
-
-      <ConnectionSettings
-        config={options}
-        onChange={onOptionsChange}
-        urlPlaceholder="http://localhost/zabbix/api_jsonrpc.php"
-      />
-
-      <Divider />
-
-      <Auth
-        {...convertLegacyAuthProps({
-          config: options,
-          onChange: onOptionsChange,
-        })}
-      />
-
-      <Divider />
-
-      <ConfigSection title="Zabbix Connection">
-        <Field label="Auth type">
-          <Combobox
-            width={40}
-            options={authOptions}
-            value={options.jsonData.authType}
-            onChange={jsonDataSelectHandler('authType', options, onOptionsChange)}
+      <Box width="60%" flex="1 1 auto" minWidth={CONTAINER_MIN_WIDTH}>
+        <Box marginBottom={4}>
+          <DataSourceDescription
+            dataSourceName="Zabbix"
+            docsLink="https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/configuration/"
+            hasRequiredFields={true}
           />
-        </Field>
+        </Box>
 
-        {options.jsonData?.authType === ZabbixAuthType.UserLogin && (
-          <>
-            <Field label="Username">
-              <Input
-                width={40}
-                placeholder="Username"
-                value={options.jsonData.username || ''}
-                onChange={jsonDataChangeHandler('username', options, onOptionsChange)}
-              />
-            </Field>
-            <Field label="Password">
-              <SecretInput
-                width={40}
-                placeholder="Password"
-                isConfigured={options.secureJsonFields && options.secureJsonFields.password}
-                onReset={resetSecureJsonField('password', options, onOptionsChange)}
-                onBlur={secureJsonDataChangeHandler('password', options, onOptionsChange)}
-              />
-            </Field>
-          </>
-        )}
+        <ConfigSectionBox
+          id={CONFIG_SECTION_HEADERS[0].id}
+          title="Zabbix connection"
+          description={
+            <>
+              Enter the full URL of the Zabbix web frontend and the credentials used to authenticate against the Zabbix
+              API. If you need further guidance, visit the{' '}
+              <TextLink href="https://grafana.com/grafana/plugins/alexanderzobnin-zabbix-app/" external>
+                Grafana docs
+              </TextLink>
+            </>
+          }
+        >
+          <Field
+            label="URL"
+            required
+            invalid={!!options.url && !isValidUrl(options.url)}
+            error="Please enter a valid URL"
+            description="Full URL of the Zabbix API endpoint"
+          >
+            <Input
+              id="zabbix-url"
+              name="url"
+              placeholder="http://localhost/zabbix/api_jsonrpc.php"
+              aria-label="Data source connection URL"
+              value={options.url || ''}
+              onChange={(event) => onOptionsChange({ ...options, url: event.currentTarget.value })}
+            />
+          </Field>
 
-        {options.jsonData?.authType === ZabbixAuthType.Token && (
-          <>
-            <Field label="API Token">
+          <Field label="Auth type" description="How the plugin signs in to the Zabbix API">
+            <Combobox
+              id="zabbix-auth-type"
+              width={40}
+              options={authOptions}
+              value={options.jsonData.authType}
+              onChange={jsonDataSelectHandler('authType', options, onOptionsChange)}
+            />
+          </Field>
+
+          {options.jsonData?.authType === ZabbixAuthType.UserLogin && (
+            <div className={styles.fieldRow}>
+              <Field
+                label="Username"
+                description="Zabbix user with sufficient permissions to read the monitored data"
+                required
+              >
+                <Input
+                  id="zabbix-username"
+                  name="username"
+                  placeholder="Enter username"
+                  aria-label="Username"
+                  value={options.jsonData.username || ''}
+                  onChange={jsonDataChangeHandler('username', options, onOptionsChange)}
+                />
+              </Field>
+              <Field label="Password" description="Password of the Zabbix user" required>
+                <SecretInput
+                  id="zabbix-password"
+                  name="password"
+                  placeholder="Enter password"
+                  aria-label="Password"
+                  isConfigured={options.secureJsonFields && options.secureJsonFields.password}
+                  onReset={resetSecureJsonField('password', options, onOptionsChange)}
+                  onBlur={secureJsonDataChangeHandler('password', options, onOptionsChange)}
+                />
+              </Field>
+            </div>
+          )}
+
+          {options.jsonData?.authType === ZabbixAuthType.Token && (
+            <Field
+              label="API Token"
+              description="Token generated in Zabbix under User settings → API tokens (Zabbix 5.4 or later)"
+              required
+            >
               <SecretInput
-                width={40}
-                placeholder="API token"
+                id="zabbix-api-token"
+                name="apiToken"
+                placeholder="Enter API token"
+                aria-label="API token"
                 isConfigured={options.secureJsonFields && options.secureJsonFields.apiToken}
                 onReset={resetSecureJsonField('apiToken', options, onOptionsChange)}
                 onBlur={secureJsonDataChangeHandler('apiToken', options, onOptionsChange)}
               />
             </Field>
-          </>
-        )}
-      </ConfigSection>
-
-      <Divider />
-
-      <ConfigSection title="Additional settings" isCollapsible>
-        <AdvancedHttpSettings config={options} onChange={onOptionsChange} />
-
-        <div className={styles.space} />
-
-        <ConfigSubSection title="Zabbix API">
-          <Field
-            label={
-              <Label>
-                <EditorStack gap={0.5}>
-                  <span>Cache TTL</span>
-                  <Tooltip
-                    content={
-                      <span>
-                        Zabbix data source caches metric names in memory. Specify how often data will be updated.
-                      </span>
-                    }
-                  >
-                    <Icon name="info-circle" size="sm" />
-                  </Tooltip>
-                </EditorStack>
-              </Label>
-            }
-          >
-            <Input
-              width={40}
-              value={options.jsonData.cacheTTL || ''}
-              placeholder="1h"
-              onChange={jsonDataChangeHandler('cacheTTL', options, onOptionsChange)}
-            />
-          </Field>
-
-          <Field
-            label={
-              <Label>
-                <EditorStack gap={0.5}>
-                  <span>Timeout</span>
-                  <Tooltip content={<span>Zabbix API connection timeout in seconds. Default is 30.</span>}>
-                    <Icon name="info-circle" size="sm" />
-                  </Tooltip>
-                </EditorStack>
-              </Label>
-            }
-          >
-            <Input
-              width={40}
-              type="number"
-              value={options.jsonData.timeout}
-              placeholder="30"
-              onChange={(event) => {
-                onOptionsChange({
-                  ...options,
-                  jsonData: { ...options.jsonData, timeout: parseInt(event.currentTarget.value, 10) },
-                });
-              }}
-            />
-          </Field>
-        </ConfigSubSection>
-
-        <ConfigSubSection title="Query Options">
-          <Field
-            label={
-              <Label>
-                <EditorStack gap={0.5}>
-                  <span>Query Timeout</span>
-                  <Tooltip
-                    content={
-                      <span>
-                        Maximum execution time in seconds for database queries initiated by the plugin. Queries
-                        exceeding this limit will be automatically terminated. Default is 60 seconds.
-                      </span>
-                    }
-                  >
-                    <Icon name="info-circle" size="sm" />
-                  </Tooltip>
-                </EditorStack>
-              </Label>
-            }
-          >
-            <Input
-              width={40}
-              type="number"
-              value={options.jsonData.queryTimeout}
-              placeholder="60"
-              onChange={(event) => {
-                onOptionsChange({
-                  ...options,
-                  jsonData: {
-                    ...options.jsonData,
-                    queryTimeout: parseInt(event.currentTarget.value, 10) || undefined,
-                  },
-                });
-              }}
-            />
-          </Field>
-        </ConfigSubSection>
-
-        <ConfigSubSection title="Trends">
-          <Field label="Enable Trends">
-            <Switch
-              value={options.jsonData.trends}
-              onChange={jsonDataSwitchHandler('trends', options, onOptionsChange)}
-            />
-          </Field>
-
-          {options.jsonData.trends && (
-            <>
-              <Field
-                label={
-                  <Label>
-                    <EditorStack gap={0.5}>
-                      <span>After</span>
-                      <Tooltip
-                        content={
-                          <span>
-                            Time after which trends will be used. Best practice is to set this value to your history
-                            storage period (7d, 30d, etc).
-                          </span>
-                        }
-                      >
-                        <Icon name="info-circle" size="sm" />
-                      </Tooltip>
-                    </EditorStack>
-                  </Label>
-                }
-              >
-                <Input
-                  width={40}
-                  placeholder="7d"
-                  value={options.jsonData.trendsFrom || ''}
-                  onChange={jsonDataChangeHandler('trendsFrom', options, onOptionsChange)}
-                />
-              </Field>
-              <Field
-                label={
-                  <Label>
-                    <EditorStack gap={0.5}>
-                      <span>Range</span>
-                      <Tooltip
-                        content={
-                          <span>
-                            Time range width after which trends will be used instead of history. It&aposs better to set
-                            this value in range of 4 to 7 days to prevent loading large amount of history data.
-                          </span>
-                        }
-                      >
-                        <Icon name="info-circle" size="sm" />
-                      </Tooltip>
-                    </EditorStack>
-                  </Label>
-                }
-              >
-                <Input
-                  width={40}
-                  placeholder="4d"
-                  value={options.jsonData.trendsRange || ''}
-                  onChange={jsonDataChangeHandler('trendsRange', options, onOptionsChange)}
-                />
-              </Field>
-            </>
           )}
-        </ConfigSubSection>
+        </ConfigSectionBox>
 
-        <ConfigSubSection title="Direct DB Connection">
-          <Field label="Enable Direct DB Connection">
-            <Switch
-              value={options.jsonData.dbConnectionEnable}
-              onChange={jsonDataSwitchHandler('dbConnectionEnable', options, onOptionsChange)}
+        <ConfigSectionBox
+          id={CONFIG_SECTION_HEADERS[1].id}
+          title="TLS/SSL settings"
+          isOptional
+          isInitiallyOpen={tlsSettingsOpen}
+        >
+          <div className={styles.tlsSettingsWrapper}>
+            {authProps.TLS && <TLSSettings {...authProps.TLS} readOnly={!!options.readOnly} />}
+          </div>
+        </ConfigSectionBox>
+
+        <ConfigSectionBox
+          id={CONFIG_SECTION_HEADERS[2].id}
+          title="HTTP settings"
+          isOptional
+          isInitiallyOpen={httpSettingsOpen}
+          description="Settings for the HTTP connection between Grafana and the Zabbix web server. Use Basic authentication only when the Zabbix web frontend sits behind a reverse proxy that requires its own credentials. This is separate from the Zabbix API credentials configured above"
+        >
+          <Field label="Authentication method">
+            <Combobox
+              id="zabbix-http-auth-method"
+              width={40}
+              options={httpAuthOptions}
+              value={options.basicAuth ? 'basic' : 'none'}
+              onChange={(option) => onOptionsChange({ ...options, basicAuth: option.value === 'basic' })}
             />
           </Field>
 
-          {options.jsonData.dbConnectionEnable && (
-            <>
-              <Field label="Data Source">
-                <Combobox
-                  width={40}
-                  value={selectedDBDatasource}
-                  options={getDirectDBDSOptions()}
-                  onChange={directDBDatasourceChangeHandler(options, onOptionsChange)}
-                  placeholder="Select a DB datasource (MySQL, PostgreSQL, InfluxDB)"
+          {options.basicAuth && (
+            <div className={styles.fieldRow}>
+              <Field label="User" description="Username expected by the reverse proxy">
+                <Input
+                  id="zabbix-basic-auth-user"
+                  name="basicAuthUser"
+                  placeholder="Enter username"
+                  aria-label="Basic auth user"
+                  value={options.basicAuthUser || ''}
+                  onChange={(event) => authProps.basicAuth?.onUserChange(event.currentTarget.value)}
+                />
+              </Field>
+              <Field label="Password" description="Password expected by the reverse proxy">
+                <SecretInput
+                  id="zabbix-basic-auth-password"
+                  name="basicAuthPassword"
+                  placeholder="Enter basic auth password"
+                  aria-label="Basic auth password"
+                  isConfigured={!!options.secureJsonFields?.basicAuthPassword}
+                  onReset={() => authProps.basicAuth?.onPasswordReset()}
+                  onBlur={(event) => authProps.basicAuth?.onPasswordChange(event.currentTarget.value)}
+                />
+              </Field>
+            </div>
+          )}
+
+          <CustomHeadersSettings dataSourceConfig={options} onChange={onOptionsChange} />
+
+          <ConfigSubSection title="Advanced HTTP settings">
+            <Field
+              label="Allowed cookies"
+              description="Grafana proxy deletes forwarded cookies by default. Specify cookies by name that should be forwarded to the data source"
+            >
+              <TagsInput
+                id="zabbix-allowed-cookies"
+                placeholder="Enter cookie name (hit enter to add)"
+                tags={options.jsonData.keepCookies}
+                onChange={(cookies) =>
+                  onOptionsChange({ ...options, jsonData: { ...options.jsonData, keepCookies: cookies } })
+                }
+              />
+            </Field>
+          </ConfigSubSection>
+        </ConfigSectionBox>
+
+        <ConfigSectionBox
+          id={CONFIG_SECTION_HEADERS[3].id}
+          title="Additional settings"
+          isOptional
+          isInitiallyOpen={additionalSettingsOpen}
+          description="Additional settings are optional settings that can be configured for more control over your data source. This includes trends, cache, direct DB connection and per-user authentication"
+        >
+          <ConfigSubSection title="Zabbix API" description="Fine-tune how the plugin communicates with the Zabbix API">
+            <div className={styles.fieldRow}>
+              <Field
+                label="Cache TTL"
+                description="Zabbix data source caches metric names in memory. Specify how often data will be updated"
+              >
+                <Input
+                  id="zabbix-cache-ttl"
+                  name="cacheTTL"
+                  value={options.jsonData.cacheTTL || ''}
+                  placeholder="1h"
+                  aria-label="Cache TTL"
+                  onChange={jsonDataChangeHandler('cacheTTL', options, onOptionsChange)}
                 />
               </Field>
 
-              {currentDSType === 'influxdb' && (
-                <Field label="Retention Policy">
+              <Field label="Timeout" description="Zabbix API connection timeout in seconds. Default is 30">
+                <Input
+                  id="zabbix-timeout"
+                  name="timeout"
+                  type="number"
+                  value={options.jsonData.timeout}
+                  placeholder="30"
+                  aria-label="Timeout"
+                  onChange={(event) => {
+                    onOptionsChange({
+                      ...options,
+                      jsonData: { ...options.jsonData, timeout: parseInt(event.currentTarget.value, 10) },
+                    });
+                  }}
+                />
+              </Field>
+            </div>
+          </ConfigSubSection>
+
+          <Divider />
+
+          <ConfigSubSection title="Query options" description="Limits applied to queries issued by the plugin">
+            <Field
+              label="Query Timeout"
+              description="Maximum execution time in seconds for database queries initiated by the plugin. Queries exceeding this limit will be automatically terminated. Default is 60 seconds"
+            >
+              <Input
+                id="zabbix-query-timeout"
+                name="queryTimeout"
+                type="number"
+                value={options.jsonData.queryTimeout}
+                placeholder="60"
+                aria-label="Query Timeout"
+                onChange={(event) => {
+                  onOptionsChange({
+                    ...options,
+                    jsonData: {
+                      ...options.jsonData,
+                      queryTimeout: parseInt(event.currentTarget.value, 10) || undefined,
+                    },
+                  });
+                }}
+              />
+            </Field>
+          </ConfigSubSection>
+
+          <Divider />
+
+          <ConfigSubSection
+            title="Trends"
+            description="Use trend data for long time ranges to improve performance and query data beyond the history storage period"
+          >
+            <Field label="Enable Trends">
+              <Switch
+                id="zabbix-enable-trends"
+                value={options.jsonData.trends}
+                onChange={jsonDataSwitchHandler('trends', options, onOptionsChange)}
+              />
+            </Field>
+
+            {options.jsonData.trends && (
+              <div className={styles.fieldRow}>
+                <Field
+                  label="After"
+                  description="Time after which trends will be used. Best practice is to set this value to your history storage period (7d, 30d, etc)"
+                >
                   <Input
-                    width={40}
-                    value={options.jsonData.dbConnectionRetentionPolicy || ''}
-                    placeholder="Retention policy name"
-                    onChange={jsonDataChangeHandler('dbConnectionRetentionPolicy', options, onOptionsChange)}
-                    // tooltip="Specify retention policy name for fetching long-term stored data (optional).
-                    // Leave it blank if only default retention policy used."
+                    id="zabbix-trends-after"
+                    name="trendsFrom"
+                    placeholder="7d"
+                    aria-label="After"
+                    value={options.jsonData.trendsFrom || ''}
+                    onChange={jsonDataChangeHandler('trendsFrom', options, onOptionsChange)}
                   />
                 </Field>
-              )}
-            </>
-          )}
-        </ConfigSubSection>
+                <Field
+                  label="Range"
+                  description="Time range width after which trends will be used instead of history. It's better to set this value in range of 4 to 7 days to prevent loading large amount of history data"
+                >
+                  <Input
+                    id="zabbix-trends-range"
+                    name="trendsRange"
+                    placeholder="4d"
+                    aria-label="Range"
+                    value={options.jsonData.trendsRange || ''}
+                    onChange={jsonDataChangeHandler('trendsRange', options, onOptionsChange)}
+                  />
+                </Field>
+              </div>
+            )}
+          </ConfigSubSection>
 
-        <ConfigSubSection title="Other">
-          <Field label="Disable acknowledges for read-only users">
-            <Switch
-              label="Disable acknowledges for read-only users"
-              value={options.jsonData.disableReadOnlyUsersAck}
-              onChange={jsonDataSwitchHandler('disableReadOnlyUsersAck', options, onOptionsChange)}
-            />
-          </Field>
+          <Divider />
 
-          <Field
-            label={
-              <Label>
-                <EditorStack gap={0.5}>
-                  <span>Disable data alignment</span>
-                  <Tooltip
-                    content={
-                      <span>
-                        Data alignment feature aligns points based on item update interval. For instance, if value
-                        collected once per minute, then timestamp of the each point will be set to the start of
-                        corresponding minute. This alignment required for proper work of the stacked graphs. If you
-                        don&apos;t need stacked graphs and want to get exactly the same timestamps as in Zabbix, then
-                        you can disable this feature.
-                      </span>
-                    }
-                  >
-                    <Icon name="info-circle" size="sm" />
-                  </Tooltip>
-                </EditorStack>
-              </Label>
-            }
+          <ConfigSubSection
+            title="Direct DB Connection"
+            description="Query history and trends directly from the Zabbix database instead of the API. This is usually significantly faster for large amounts of data"
           >
-            <Switch
-              value={!!options.jsonData.disableDataAlignment}
-              onChange={jsonDataSwitchHandler('disableDataAlignment', options, onOptionsChange)}
-            />
-          </Field>
+            <Field label="Enable Direct DB Connection">
+              <Switch
+                id="zabbix-enable-db-connection"
+                value={options.jsonData.dbConnectionEnable}
+                onChange={jsonDataSwitchHandler('dbConnectionEnable', options, onOptionsChange)}
+              />
+            </Field>
 
-          <Field
-            label={
-              <Label>
-                <EditorStack gap={0.5}>
-                  <span>Enable per-user authentication</span>
-                  <Tooltip
-                    content={
-                      <span>
-                        Enable this option if you want to use per-user authentication. This will map Grafana users to
-                        Zabbix users respecting the RBAC already setup in Zabbix.
-                      </span>
-                    }
+            {options.jsonData.dbConnectionEnable && (
+              <>
+                <Field
+                  label="Data Source"
+                  description="Data source pointing at the Zabbix history database (MySQL, PostgreSQL or InfluxDB)"
+                >
+                  <Combobox
+                    id="zabbix-db-datasource"
+                    value={selectedDBDatasource}
+                    options={getDirectDBDSOptions()}
+                    onChange={directDBDatasourceChangeHandler(options, onOptionsChange)}
+                    placeholder="Select a DB datasource (MySQL, PostgreSQL, InfluxDB)"
+                  />
+                </Field>
+
+                {currentDSType === 'influxdb' && (
+                  <Field
+                    label="Retention Policy"
+                    description="Specify retention policy name for fetching long-term stored data (optional). Leave it blank if only default retention policy used"
                   >
-                    <Icon name="info-circle" size="sm" />
-                  </Tooltip>
-                </EditorStack>
-              </Label>
-            }
-          >
-            <Switch
-              value={!!options.jsonData.perUserAuth}
-              onChange={jsonDataSwitchHandler('perUserAuth', options, onOptionsChange)}
-            />
-          </Field>
+                    <Input
+                      id="zabbix-retention-policy"
+                      name="dbConnectionRetentionPolicy"
+                      value={options.jsonData.dbConnectionRetentionPolicy || ''}
+                      placeholder="Retention policy name"
+                      aria-label="Retention Policy"
+                      onChange={jsonDataChangeHandler('dbConnectionRetentionPolicy', options, onOptionsChange)}
+                    />
+                  </Field>
+                )}
+              </>
+            )}
+          </ConfigSubSection>
 
-          {options.jsonData.perUserAuth && (
+          <Divider />
+
+          <ConfigSubSection
+            title="Per-user authentication"
+            description="Map Grafana users to Zabbix users respecting the RBAC already set up in Zabbix"
+          >
+            <Field label="Enable per-user authentication">
+              <Switch
+                id="zabbix-per-user-auth"
+                value={!!options.jsonData.perUserAuth}
+                onChange={jsonDataSwitchHandler('perUserAuth', options, onOptionsChange)}
+              />
+            </Field>
+
+            {options.jsonData.perUserAuth && (
+              <>
+                {userFetchWarning && (
+                  <Alert title="Cannot list Grafana users" severity="warning">
+                    {userFetchWarning}
+                  </Alert>
+                )}
+
+                <div className={styles.fieldRow}>
+                  <Field
+                    label="User identity field"
+                    description="Grafana user attribute matched against the Zabbix username"
+                  >
+                    <Combobox
+                      id="zabbix-per-user-auth-field"
+                      options={userIdentityOptions}
+                      value={{
+                        label: options.jsonData.perUserAuthField === 'email' ? 'Email' : 'Username',
+                        value: options.jsonData.perUserAuthField || 'username',
+                      }}
+                      onChange={jsonDataSelectHandler('perUserAuthField', options, onOptionsChange)}
+                    />
+                  </Field>
+
+                  <Field
+                    label="Exclude users from per-user authentication"
+                    description="These users will always use the global Zabbix credentials"
+                  >
+                    <MultiSelect
+                      inputId="zabbix-per-user-auth-exclude"
+                      options={grafanaUsers}
+                      allowCustomValue
+                      value={(options.jsonData.perUserAuthExcludeUsers ?? ['admin']).map(
+                        (u) => ({ label: u, value: u }) as SelectableValue<string>
+                      )}
+                      onChange={
+                        canEditExcludedUsers
+                          ? (selected) => {
+                              onOptionsChange({
+                                ...options,
+                                jsonData: {
+                                  ...options.jsonData,
+                                  perUserAuthExcludeUsers: selected.map((s) => s.value),
+                                },
+                              });
+                            }
+                          : undefined
+                      }
+                      disabled={!canEditExcludedUsers}
+                    />
+                  </Field>
+                </div>
+              </>
+            )}
+          </ConfigSubSection>
+
+          <Divider />
+
+          <ConfigSubSection title="Other">
+            <Field label="Disable acknowledges for read-only users">
+              <Switch
+                id="zabbix-disable-ro-ack"
+                value={options.jsonData.disableReadOnlyUsersAck}
+                onChange={jsonDataSwitchHandler('disableReadOnlyUsersAck', options, onOptionsChange)}
+              />
+            </Field>
+
+            <Field
+              label="Disable data alignment"
+              description="Data alignment feature aligns points based on item update interval. For instance, if value collected once per minute, then timestamp of the each point will be set to the start of corresponding minute. This alignment required for proper work of the stacked graphs. If you don't need stacked graphs and want to get exactly the same timestamps as in Zabbix, then you can disable this feature"
+            >
+              <Switch
+                id="zabbix-disable-data-alignment"
+                value={!!options.jsonData.disableDataAlignment}
+                onChange={jsonDataSwitchHandler('disableDataAlignment', options, onOptionsChange)}
+              />
+            </Field>
+          </ConfigSubSection>
+
+          {config.secureSocksDSProxyEnabled && gte(config.buildInfo.version, '10.0.0-0') && (
             <>
-              <Field
-                label={
-                  <Label>
-                    <EditorStack gap={0.5}>
-                      <span>User identity field</span>
-                    </EditorStack>
-                  </Label>
-                }
-              >
-                <Combobox
-                  width={40}
-                  options={
-                    [
-                      { label: 'Username', value: 'username' },
-                      { label: 'Email', value: 'email' },
-                    ] as Array<ComboboxOption<string>>
-                  }
-                  value={{
-                    label: options.jsonData.perUserAuthField === 'email' ? 'Email' : 'Username',
-                    value: options.jsonData.perUserAuthField || 'username',
-                  }}
-                  onChange={jsonDataSelectHandler('perUserAuthField', options, onOptionsChange)}
-                />
-              </Field>
-
-              {userFetchWarning && (
-                <Alert title="Cannot list Grafana users" severity="warning">
-                  {userFetchWarning}
-                </Alert>
-              )}
-
-              <Field
-                label={
-                  <Label>
-                    <EditorStack gap={0.5}>
-                      <span>Exclude users from per-user authentication</span>
-                      <Tooltip content={<span>These users will always use the global Zabbix credentials</span>}>
-                        <Icon name="info-circle" size="sm" />
-                      </Tooltip>
-                    </EditorStack>
-                  </Label>
-                }
-              >
-                <MultiSelect
-                  width={40}
-                  options={grafanaUsers}
-                  allowCustomValue
-                  value={(options.jsonData.perUserAuthExcludeUsers ?? ['admin']).map(
-                    (u) => ({ label: u, value: u }) as SelectableValue<string>
-                  )}
-                  onChange={
-                    canEditExcludedUsers
-                      ? (selected) => {
-                          onOptionsChange({
-                            ...options,
-                            jsonData: {
-                              ...options.jsonData,
-                              perUserAuthExcludeUsers: selected.map((s) => s.value),
-                            },
-                          });
-                        }
-                      : undefined
-                  }
-                  disabled={!canEditExcludedUsers}
-                />
-              </Field>
+              <Divider />
+              <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
             </>
           )}
-        </ConfigSubSection>
+        </ConfigSectionBox>
+      </Box>
 
-        {config.secureSocksDSProxyEnabled && gte(config.buildInfo.version, '10.0.0-0') && (
-          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
-        )}
-      </ConfigSection>
-    </>
+      <Box width="20%" flex="0 0 20%">
+        {/* Reserved for a right sidebar, mirroring the new Grafana config design */}
+      </Box>
+    </Stack>
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    space: css({
-      width: '100%',
-      height: theme.spacing(2),
-    }),
-  };
-};
+const getStyles = (theme: GrafanaTheme2) => ({
+  // Lays out sibling fields side by side, each filling an equal share of the
+  // section box and wrapping on narrow screens (ClickHouse config-v2 pattern).
+  // Each field is a column with a growing label block so the inputs stay
+  // bottom-aligned even when one description wraps to more lines.
+  fieldRow: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+
+    '& > div': {
+      flex: '1 1 300px',
+      minWidth: 0,
+      display: 'flex',
+      flexDirection: 'column',
+
+      '& > div:first-child': {
+        flexGrow: 1,
+      },
+    },
+  }),
+  optionalBadge: css({
+    marginLeft: 'auto',
+  }),
+  // TLSSettings hard-codes a top margin on its container, which stacks with
+  // the CollapsableSection content padding into a large empty gap.
+  tlsSettingsWrapper: css({
+    '& > div': {
+      marginTop: 0,
+    },
+  }),
+  leftSidebarWrapper: css({
+    width: '250px',
+    flex: '0 0 250px',
+    position: 'sticky',
+    top: '100px',
+    alignSelf: 'flex-start',
+    maxHeight: 'calc(100vh - 100px)',
+    overflow: 'hidden',
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+  }),
+});
 
 const jsonDataChangeHandler =
   (

--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -29,13 +29,7 @@ import {
 } from '@grafana/ui';
 import { ZabbixAuthType, ZabbixDSOptions, ZabbixSecureJSONData } from '../types/config';
 import { gte } from 'semver';
-import {
-  ConfigSubSection,
-  convertLegacyAuthProps,
-  CustomHeadersSettings,
-  DataSourceDescription,
-  TLSSettings,
-} from '@grafana/plugin-ui';
+import { ConfigSubSection, convertLegacyAuthProps, CustomHeadersSettings, TLSSettings } from '@grafana/plugin-ui';
 import { css } from '@emotion/css';
 import { Divider } from './Divider';
 import { CONFIG_SECTION_HEADERS, LeftSidebar } from './LeftSidebar';
@@ -281,12 +275,10 @@ export const ConfigEditor = (props: Props) => {
       </div>
 
       <Box width="60%" flex="1 1 auto" minWidth={CONTAINER_MIN_WIDTH}>
-        <Box marginBottom={4}>
-          <DataSourceDescription
-            dataSourceName="Zabbix"
-            docsLink="https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/configuration/"
-            hasRequiredFields={true}
-          />
+        <Box marginBottom={2}>
+          <Text variant="bodySmall" color="secondary">
+            Fields marked with * are required
+          </Text>
         </Box>
 
         <ConfigSectionBox

--- a/src/datasource/components/LeftSidebar.tsx
+++ b/src/datasource/components/LeftSidebar.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { Box, Icon, LinkButton, Space, Stack, Text, useStyles2 } from '@grafana/ui';
+
+export interface ConfigSectionHeader {
+  label: string;
+  id: string;
+  isOptional: boolean;
+}
+
+// The Grafana "Save & test" button doesn't carry an element id, so the sidebar
+// entry for it falls back to scrolling to the bottom of the page.
+export const SAVE_AND_TEST_SECTION_ID = 'zabbix-config-save-and-test';
+
+export const CONFIG_SECTION_HEADERS: ConfigSectionHeader[] = [
+  { label: 'Zabbix connection', id: 'zabbix-config-connection', isOptional: false },
+  { label: 'TLS/SSL settings', id: 'zabbix-config-tls', isOptional: true },
+  { label: 'HTTP settings', id: 'zabbix-config-http', isOptional: true },
+  { label: 'Additional settings', id: 'zabbix-config-additional-settings', isOptional: true },
+  { label: 'Save & test', id: SAVE_AND_TEST_SECTION_ID, isOptional: false },
+];
+
+export const LeftSidebar = () => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack>
+      <Box flex={1} marginY={1}>
+        <Text element="h4">Connect data source</Text>
+        <Box paddingTop={2}>
+          {CONFIG_SECTION_HEADERS.map((header) => (
+            <div key={header.id} data-testid={`${header.label}-sidebar`}>
+              <Icon name="circle" size="xs" />
+              <LinkButton
+                style={header.isOptional ? { padding: '5px 15px', height: '50px' } : {}}
+                variant="secondary"
+                fill="text"
+                onClick={(e) => {
+                  e.preventDefault();
+                  const target = document.getElementById(header.id);
+                  if (target) {
+                    const top = target.getBoundingClientRect().top + window.scrollY - 60;
+                    window.scrollTo({ top, behavior: 'smooth' });
+                  } else {
+                    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+                  }
+                }}
+              >
+                <div className={styles.sidebarText}>
+                  <div className={styles.sidebarLabel}>{header.label}</div>
+                  {header.isOptional && (
+                    <div className={styles.sidebarOptional}>
+                      <Text color="secondary" variant="bodySmall">
+                        optional
+                      </Text>
+                    </div>
+                  )}
+                </div>
+              </LinkButton>
+              <Space v={1} />
+            </div>
+          ))}
+        </Box>
+      </Box>
+    </Stack>
+  );
+};
+
+const getStyles = () => ({
+  sidebarText: css({
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+  sidebarLabel: css({
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: 0,
+    lineHeight: 1,
+  }),
+  sidebarOptional: css({
+    marginTop: 0,
+    marginBottom: 0,
+    lineHeight: 1,
+    textAlign: 'left',
+  }),
+});

--- a/src/datasource/types/config.ts
+++ b/src/datasource/types/config.ts
@@ -22,6 +22,14 @@ export type ZabbixDSOptions = {
   disableReadOnlyUsersAck: boolean;
   disableDataAlignment: boolean;
   enableSecureSocksProxy?: boolean;
+  /** Cookies forwarded to the Zabbix web server by the Grafana proxy */
+  keepCookies?: string[];
+  /** Standard Grafana datasource HTTP options (TLS and custom headers) */
+  tlsAuth?: boolean;
+  tlsAuthWithCACert?: boolean;
+  tlsSkipVerify?: boolean;
+  serverName?: string;
+  httpHeaderName1?: string;
   /** @deprecated
    * Use `dbConnectionEnable` `dbConnectionDatasourceUID` `dbConnectionDatasourceName` `dbConnectionRetentionPolicy` instead.
    * Currently only used to support migration for older schemas.

--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -14,16 +14,16 @@ test.describe('Config editor', () => {
       { tag: '@plugins' },
       async ({ createDataSourceConfigPage, page }) => {
         await createDataSourceConfigPage({ type: PLUGIN_TYPE });
-        await expect(page.getByRole('heading', { name: 'Zabbix Connection' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Zabbix connection' })).toBeVisible();
       }
     );
 
     test('renders the connection, auth and Zabbix sections', async ({ createDataSourceConfigPage, page }) => {
       await createDataSourceConfigPage({ type: PLUGIN_TYPE });
-      await expect(page.getByText('Connection', { exact: true })).toBeVisible();
-      await expect(page.getByText('Authentication', { exact: true })).toBeVisible();
-      await expect(page.getByRole('heading', { name: 'Zabbix Connection' })).toBeVisible();
-      await expect(page.getByText('Additional settings')).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Zabbix connection' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'TLS/SSL settings' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'HTTP settings' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Additional settings' })).toBeVisible();
       await expect(page.getByText('Auth type')).toBeVisible();
     });
   });
@@ -49,7 +49,7 @@ test.describe('Config editor', () => {
       const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
       await page.getByRole('textbox', { name: 'Data source connection URL' }).fill(REACHABLE_URL);
       await page.getByRole('textbox', { name: 'Username' }).fill('Admin');
-      await page.getByPlaceholder('Password').fill('zabbix');
+      await page.getByPlaceholder('Enter password').fill('zabbix');
       await configPage.saveAndTest();
       await expect(page.getByText(/Zabbix API version/i)).toBeVisible({ timeout: 15000 });
     });
@@ -58,7 +58,7 @@ test.describe('Config editor', () => {
       const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
       await page.getByRole('textbox', { name: 'Data source connection URL' }).fill('http://localhost:1/api_jsonrpc.php');
       await page.getByRole('textbox', { name: 'Username' }).fill('Admin');
-      await page.getByPlaceholder('Password').fill('zabbix');
+      await page.getByPlaceholder('Enter password').fill('zabbix');
       await configPage.saveAndTest();
       await expect(page.getByText(/Zabbix API version/i)).toBeHidden();
     });


### PR DESCRIPTION
Closes #2537 

## What this PR does

Rebuilds the datasource configuration page following the new Grafana
datasource config design, as introduced by the ClickHouse datasource.

### Layout

- Each settings group now lives in a bordered, collapsible section box.
  Clicking anywhere on the header toggles it, optional sections show an
  "optional" badge in the top-right corner, and every optional section starts
  collapsed unless one of its settings is already configured.
- A sticky "Connect data source" sidebar on the left scrolls to each section
  and to Save & test (hidden on small screens).
- Related fields are laid out side by side and fill the section width
  (username/password, cache TTL/timeout, trends after/range, per-user
  authentication fields), with inline descriptions replacing tooltip icons.

### Sections

1. **Zabbix connection** - URL plus the Zabbix API credentials (auth type,
   username/password or API token). Merges the previous generic
   Connection/Authentication blocks with the Zabbix credentials section.
2. **TLS/SSL settings** *(optional)* - self-signed CA, client auth, skip
   verify (unchanged fields, wired through `convertLegacyAuthProps`).
3. **HTTP settings** *(optional)* - HTTP authentication reduced to
   **No Authentication / Basic authentication**, with a note that basic auth
   is for a reverse proxy in front of the Zabbix web frontend. Custom HTTP
   headers and allowed cookies moved here.
4. **Additional settings** *(optional)* - cache, timeouts, trends, direct DB
   connection, per-user authentication, misc toggles and the secure SOCKS
   proxy, unchanged.

### Behavior notes

- The removed HTTP auth methods (Forward OAuth Identity, With Credentials)
  were no-ops: the frontend routes every Zabbix API call through the backend
  resource endpoint, and the backend HTTP client (SDK `HTTPClientOptions`)
  only honors basic auth, TLS options and custom headers.
- The Advanced HTTP settings "Timeout" input edited the same
  `jsonData.timeout` as the Zabbix API "Timeout" field; only one input for it
  remains (in Additional settings → Zabbix API).
- No stored fields changed shape - existing provisioned/saved datasources load
  unchanged.

## Testing

- Unit tests pass; e2e specs updated for the new section headings and labels.
- Manually verified the page renders and behaves correctly on Grafana
  **11.6.0, 12.1.x, 12.2.x, 13.1.x and 13.2.x** (`grafanaDependency` is
  `>=11.6.0`).

## Screenshots

Screenshots captured from devenv of Grafana v13.1.3:

<img width="3418" height="1890" alt="image" src="https://github.com/user-attachments/assets/48c8238c-22bd-4f4f-bb0e-407105bdd659" />
<img width="3416" height="1882" alt="image" src="https://github.com/user-attachments/assets/312947fb-66bb-4cef-b9dd-3f887855625a" />
<img width="3404" height="1846" alt="image" src="https://github.com/user-attachments/assets/72c0693d-7be0-490b-b625-c01af7c85a9c" />
<img width="3404" height="1880" alt="image" src="https://github.com/user-attachments/assets/51e318ea-bc48-474d-997e-a101570b1f0b" />
