### PR TITLE
fix(docs): restore install/upgrade instructions and update deprecated grafana-cli command

### DIFF
--- a/.changeset/quiet-ideas-act.md
+++ b/.changeset/quiet-ideas-act.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+Docs: restore installation instructions and add an upgrade section to the docs index (the removed installation page left only aliases), update commands to the `grafana cli` subcommand since the standalone `grafana-cli` is deprecated and fails on Grafana 13.x, and fix broken installation links in the README

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Visit [plugins page](https://grafana.com/plugins) at [grafana.com](http://grafan
 
 ## Installation
 
-Install by using `grafana-cli`
+Install or upgrade by using `grafana cli` (on older Grafana versions that ship the standalone binary, use `grafana-cli` instead):
 
 ```sh
-grafana-cli plugins install alexanderzobnin-zabbix-app
+grafana cli plugins install alexanderzobnin-zabbix-app
 ```
 
-Or see more installation options in [docs](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/installation/).
+Or see more installation and upgrade options in the [docs](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/#install-the-plugin).
 
 ## Getting started
 
@@ -38,7 +38,7 @@ First, [configure](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/l
 ## Documentation
 
 - [About](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/)
-- [Installation](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/installation)
+- [Installation](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/#install-the-plugin)
 - [Getting Started](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/guides)
 - [Templating](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/guides/templating)
 - [Alerting](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/reference/alerting/)

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -29,9 +29,39 @@ The Zabbix data source connects Grafana to your Zabbix monitoring infrastructure
 ## Requirements
 
 - Grafana 11.6.0 or later.
-- The Zabbix plugin installed in your Grafana instance. You can install it from **Administration** > **Plugins and data** > **Plugins**, or refer to [Install Grafana plugins](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/plugin-management/) for other methods.
+- The Zabbix plugin installed in your Grafana instance. Refer to [Install the plugin](#install-the-plugin).
 - A running Zabbix server with API access enabled.
 - A Zabbix user account with read permissions for the host groups and hosts you want to query.
+
+## Install the plugin
+
+Install the plugin by using one of the following methods:
+
+- In Grafana, go to **Administration** > **Plugins and data** > **Plugins**, search for **Zabbix**, and click **Install**.
+- Use the Grafana CLI:
+
+  ```sh
+  grafana cli plugins install alexanderzobnin-zabbix-app
+  ```
+
+  > **Note:** In Grafana versions that ship the standalone `grafana-cli` binary, run `grafana-cli plugins install alexanderzobnin-zabbix-app` instead. The standalone binary is deprecated in favor of the `grafana cli` subcommand.
+
+For other methods, including provisioning and Docker environments, refer to [Install Grafana plugins](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/plugin-management/).
+
+Restart Grafana after you install the plugin.
+
+## Upgrade the plugin
+
+Upgrade the plugin to the latest version by using one of the following methods:
+
+- In Grafana, go to **Administration** > **Plugins and data** > **Plugins**, select **Zabbix**, and click **Update** if a newer version is available.
+- Use the Grafana CLI:
+
+  ```sh
+  grafana cli plugins update alexanderzobnin-zabbix-app
+  ```
+
+Restart Grafana after you upgrade the plugin.
 
 ## Supported features
 


### PR DESCRIPTION
Fixes #2536

## Problem

- The README instructs users to run `grafana-cli plugins install alexanderzobnin-zabbix-app`. The standalone `grafana-cli` binary is deprecated and fails on Grafana 13.1.1 (`Grafana-server Init Failed: Could not find config defaults, ...`). The `grafana cli` subcommand works.
- The README's "more installation options" link and the "Installation" entry in the Documentation list both point to `.../latest/installation/`, which 404s: the installation pages were removed from `docs/sources/` and only survive as `aliases:` on `_index.md`, so the published docs currently contain no installation or upgrade instructions at all.

## Changes

- `docs/sources/_index.md`:
  - Added an "Install the plugin" section (UI method, `grafana cli` command with a note about the deprecated standalone binary for older versions, link to the generic plugin management docs for provisioning/Docker environments).
  - Added an "Upgrade the plugin" section (UI update and `grafana cli plugins update`), addressing the point in #2536 that the docs never explained how to upgrade.
  - Simplified the Requirements bullet to point at the new install section instead of duplicating it.
- `README.md`: updated the install command to `grafana cli`, reworded to "Install or upgrade" per the suggestion in #2536, and repointed both broken links to the new docs section.

Existing `installation/` and `installation/upgrade/` aliases on `_index.md` are left untouched, so old bookmarks now land on a page that actually contains install and upgrade instructions again.