### PR TITLE
fix(functions): scale() fails when added with its default param

### DIFF
--- a/.changeset/slimy-trees-occur.md
+++ b/.changeset/slimy-trees-occur.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+fix(functions): accept numeric scale() param; add frontend/backend param-contract tests

--- a/pkg/datasource/functions.go
+++ b/pkg/datasource/functions.go
@@ -214,11 +214,7 @@ func applyPercentile(series timeseries.TimeSeries, params ...interface{}) (times
 }
 
 func applyScale(series timeseries.TimeSeries, params ...interface{}) (timeseries.TimeSeries, error) {
-	pFactor, err := MustString(params[0])
-	if err != nil {
-		return nil, errParsingFunctionParam(err)
-	}
-	factor, err := strconv.ParseFloat(pFactor, 64)
+	factor, err := MustFloat64(params[0])
 	if err != nil {
 		return nil, errParsingFunctionParam(err)
 	}

--- a/pkg/datasource/functions_test.go
+++ b/pkg/datasource/functions_test.go
@@ -1,6 +1,11 @@
 package datasource
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -8,6 +13,7 @@ import (
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/zabbix"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApplyFunctionsFunction(t *testing.T) {
@@ -186,4 +192,263 @@ func TestApplyFunctionsPreFunction(t *testing.T) {
 	// Check if the error is a downstream error
 	assert.Truef(t, backend.IsDownstreamError(err), "error is not a downstream error")
 
+}
+
+// TestApplyScale verifies scale() accepts both param encodings the frontend
+// produces: a freshly added function serializes its default factor as a JSON
+// number (defaultParams: [100]), while a value typed in the editor is stored
+// as a string.
+func TestApplyScale(t *testing.T) {
+	newSeries := func() timeseries.TimeSeries {
+		v1, v2 := 1.0, 2.0
+		return timeseries.TimeSeries{
+			{Time: time.Time{}, Value: &v1},
+			{Time: time.Time{}, Value: &v2},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		param   interface{}
+		want    []float64
+		wantErr bool
+	}{
+		{name: "numeric param (function added with default)", param: float64(100), want: []float64{100, 200}},
+		{name: "string param (value typed in editor)", param: "100", want: []float64{100, 200}},
+		{name: "invalid param", param: "not-a-number", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := applyScale(newSeries(), tt.param)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			for i, want := range tt.want {
+				assert.Equal(t, want, *result[i].Value)
+			}
+		})
+	}
+}
+
+// newTestSeriesData returns fresh series suitable for any processing function:
+// two series with monotonic timestamps, so grouping and filter functions work.
+func newTestSeriesData() []*timeseries.TimeSeriesData {
+	newTS := func(name string, values ...float64) *timeseries.TimeSeriesData {
+		start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		s := &timeseries.TimeSeriesData{}
+		s.Meta.Name = name
+		for i, v := range values {
+			value := v
+			s.TS = append(s.TS, timeseries.TimePoint{Time: start.Add(time.Duration(i) * time.Minute), Value: &value})
+		}
+		return s
+	}
+	return []*timeseries.TimeSeriesData{
+		newTS("series A", 1, 2, 3),
+		newTS("series B", 4, 5, 6),
+	}
+}
+
+// TestApplyFunctionsScale runs scale() through applyFunctions — the same
+// dispatch path the query handler uses — with both param encodings.
+func TestApplyFunctionsScale(t *testing.T) {
+	tests := []struct {
+		name  string
+		param interface{}
+	}{
+		{name: "numeric param (function added with default)", param: float64(100)},
+		{name: "string param (value typed in editor)", param: "100"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			functions := []QueryFunction{
+				{
+					Def:    QueryFunctionDef{Name: "scale"},
+					Params: []interface{}{tt.param},
+				},
+			}
+
+			result, err := applyFunctions(newTestSeriesData(), functions)
+			assert.NoError(t, err)
+			require.Len(t, result, 2)
+			assert.Equal(t, []float64{100, 200, 300}, seriesValues(t, result[0].TS))
+			assert.Equal(t, []float64{400, 500, 600}, seriesValues(t, result[1].TS))
+		})
+	}
+}
+
+func seriesValues(t *testing.T, ts timeseries.TimeSeries) []float64 {
+	t.Helper()
+	values := make([]float64, 0, len(ts))
+	for _, p := range ts {
+		require.NotNil(t, p.Value)
+		values = append(values, *p.Value)
+	}
+	return values
+}
+
+// TestQueryModelFunctionsRoundTrip unmarshals a query JSON payload shaped
+// exactly as the frontend sends it (numeric default param in functions) into
+// QueryModel via ReadQuery and runs function application on it.
+func TestQueryModelFunctionsRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		paramJSON string
+	}{
+		{name: "numeric param as saved by a fresh scale() with defaults", paramJSON: `[100]`},
+		{name: "string param as saved after typing in the editor", paramJSON: `["100"]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queryJSON := `{
+				"queryType": "0",
+				"group": {"filter": "/.*/"},
+				"host": {"filter": "backend01"},
+				"application": {"filter": ""},
+				"itemTag": {"filter": ""},
+				"item": {"filter": "CPU utilization"},
+				"functions": [
+					{
+						"def": {
+							"name": "scale",
+							"category": "Transform",
+							"params": [{"name": "factor", "type": "float", "options": [100, 0.01, 10, -1]}],
+							"defaultParams": [100]
+						},
+						"params": ` + tt.paramJSON + `,
+						"text": "scale(100)"
+					}
+				],
+				"options": {"showDisabledItems": false, "disableDataAlignment": false, "useZabbixValueMapping": false, "useTrends": "default"}
+			}`
+
+			query, err := ReadQuery(backend.DataQuery{
+				RefID:     "A",
+				QueryType: "0",
+				JSON:      []byte(queryJSON),
+			})
+			require.NoError(t, err)
+			require.Len(t, query.Functions, 1)
+
+			result, err := applyFunctions(newTestSeriesData(), query.Functions)
+			assert.NoError(t, err)
+			require.Len(t, result, 2)
+			assert.Equal(t, []float64{100, 200, 300}, seriesValues(t, result[0].TS))
+		})
+	}
+}
+
+// frontendFuncDef is a function definition parsed from the frontend source
+// (src/datasource/metricFunctions.ts): its name and its defaultParams with
+// the types json.Unmarshal would produce (float64 for numbers, string for
+// quoted values) — i.e. exactly what the backend receives for a function
+// freshly added in the query editor.
+type frontendFuncDef struct {
+	name          string
+	defaultParams []interface{}
+}
+
+// parseFrontendFuncDefs extracts every addFuncDef({...}) block from
+// metricFunctions.ts. Parsing the real frontend source keeps this contract
+// test from silently drifting: a new frontend function or a changed default
+// automatically flows into TestBackendAcceptsFrontendDefaultParams.
+func parseFrontendFuncDefs(t *testing.T) []frontendFuncDef {
+	t.Helper()
+
+	source, err := os.ReadFile(filepath.Join("..", "..", "src", "datasource", "metricFunctions.ts"))
+	require.NoError(t, err, "cannot read frontend function definitions")
+
+	blockRe := regexp.MustCompile(`(?s)addFuncDef\(\{(.*?)\}\);`)
+	nameRe := regexp.MustCompile(`name:\s*'([^']*)'`)
+	defaultParamsRe := regexp.MustCompile(`defaultParams:\s*\[([^\]]*)\]`)
+
+	var defs []frontendFuncDef
+	for _, block := range blockRe.FindAllStringSubmatch(string(source), -1) {
+		nameMatch := nameRe.FindStringSubmatch(block[1])
+		require.NotNilf(t, nameMatch, "addFuncDef block without a name: %s", block[1])
+
+		def := frontendFuncDef{name: nameMatch[1]}
+		paramsMatch := defaultParamsRe.FindStringSubmatch(block[1])
+		require.NotNilf(t, paramsMatch, "function %s: no defaultParams found", def.name)
+
+		for _, rawParam := range strings.Split(paramsMatch[1], ",") {
+			rawParam = strings.TrimSpace(rawParam)
+			if rawParam == "" {
+				continue
+			}
+			if strings.HasPrefix(rawParam, "'") && strings.HasSuffix(rawParam, "'") {
+				def.defaultParams = append(def.defaultParams, strings.Trim(rawParam, "'"))
+				continue
+			}
+			value, err := strconv.ParseFloat(rawParam, 64)
+			require.NoErrorf(t, err, "function %s: cannot parse default param %q", def.name, rawParam)
+			def.defaultParams = append(def.defaultParams, value)
+		}
+		defs = append(defs, def)
+	}
+
+	// Guard against the parser silently matching nothing after a frontend refactor.
+	require.GreaterOrEqual(t, len(defs), 15, "suspiciously few functions parsed from metricFunctions.ts — parser out of sync with the file format?")
+	names := make(map[string]bool, len(defs))
+	for _, def := range defs {
+		names[def.name] = true
+	}
+	for _, expected := range []string{"scale", "offset", "groupBy", "top", "percentile"} {
+		require.Truef(t, names[expected], "function %s not parsed from metricFunctions.ts", expected)
+	}
+
+	return defs
+}
+
+// TestBackendAcceptsFrontendDefaultParams is a cross-cutting contract test:
+// for every function the frontend offers, the backend must accept its
+// defaultParams in both encodings the frontend produces — as JSON numbers
+// (function freshly added in the editor, or a dashboard saved that way) and
+// as strings (value retyped in the editor). scale() used to fail the first
+// encoding; this catches the whole class of such drift.
+func TestBackendAcceptsFrontendDefaultParams(t *testing.T) {
+	encodings := []struct {
+		name   string
+		encode func(param interface{}) interface{}
+	}{
+		{
+			name:   "defaults as JSON numbers (freshly added function)",
+			encode: func(param interface{}) interface{} { return param },
+		},
+		{
+			name: "defaults as strings (values typed in the editor)",
+			encode: func(param interface{}) interface{} {
+				if f, ok := param.(float64); ok {
+					return strconv.FormatFloat(f, 'f', -1, 64)
+				}
+				return param
+			},
+		},
+	}
+
+	for _, def := range parseFrontendFuncDefs(t) {
+		for _, encoding := range encodings {
+			t.Run(def.name+" / "+encoding.name, func(t *testing.T) {
+				params := make([]interface{}, 0, len(def.defaultParams))
+				for _, param := range def.defaultParams {
+					params = append(params, encoding.encode(param))
+				}
+
+				functions := []QueryFunction{
+					{
+						Def:    QueryFunctionDef{Name: def.name},
+						Params: params,
+					},
+				}
+
+				_, err := applyFunctions(newTestSeriesData(), functions)
+				assert.NoErrorf(t, err, "backend rejects %s with frontend default params %v", def.name, params)
+			})
+		}
+	}
 }

--- a/src/datasource/metricFunctions.test.ts
+++ b/src/datasource/metricFunctions.test.ts
@@ -1,0 +1,56 @@
+import { createFuncInstance, getFuncDef, getCategories } from './metricFunctions';
+
+// These tests pin the param serialization contract between the query editor
+// and the backend (pkg/datasource/functions.go):
+// - a freshly added function serializes its numeric defaults as JSON numbers
+//   (params: [100]),
+// - a value typed in the editor is stored as a string (params: ["100"]),
+// so every backend function must accept both encodings for numeric params
+// (see TestBackendAcceptsFrontendDefaultParams in pkg/datasource/functions_test.go).
+describe('metric function param serialization', () => {
+  describe('scale()', () => {
+    it('uses a numeric default param when freshly added', () => {
+      const func = createFuncInstance(getFuncDef('scale'));
+
+      expect(func.params).toEqual([100]);
+      expect(typeof func.params[0]).toBe('number');
+      expect(func.text).toBe('scale(100)');
+    });
+
+    it('stores an edited param as a string', () => {
+      // Same contract as onFuncParamChange in QueryFunctionsEditor.tsx, which
+      // stores the raw editor input (a string) into params.
+      const func = createFuncInstance(getFuncDef('scale'));
+      func.updateParam('100', 0);
+
+      expect(func.params).toEqual(['100']);
+      expect(typeof func.params[0]).toBe('string');
+    });
+
+    it('bindFunction converts both param encodings to a number', () => {
+      for (const params of [[100], ['100']]) {
+        const processingFunc = jest.fn();
+        const func = createFuncInstance(getFuncDef('scale'), params);
+        const boundFunc = func.bindFunction({ scale: processingFunc });
+        boundFunc('datapoints');
+
+        expect(processingFunc).toHaveBeenCalledWith(100, 'datapoints');
+      }
+    });
+  });
+
+  it('every int/float-typed default param is serialized as a JSON number', () => {
+    // The backend accepts numeric params as JSON numbers or strings, but the
+    // defaults documented here are what a freshly added function sends.
+    const categories = getCategories();
+    for (const category of Object.keys(categories)) {
+      for (const def of categories[category]) {
+        def.params.forEach((paramDef, i) => {
+          if ((paramDef.type === 'int' || paramDef.type === 'float') && def.defaultParams[i] !== undefined) {
+            expect(typeof def.defaultParams[i]).toBe('number');
+          }
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2540

`scale()` errored with `failed to parse function param: failed to convert value to string: 100` whenever it was added through the editor and ran with its inserted default. Retyping the same value made it work.

The frontend serializes the two cases differently: `defaultParams: [100]` is copied into the query as a JSON **number**, while values typed in the editor are stored as **strings**. `applyScale` was the only numeric function using `MustString` + `strconv.ParseFloat`, so it rejected the numeric form; its siblings (`offset`, `removeAboveValue`, `transformNull`, …) all use `MustFloat64`, which accepts both.

### Changes

- `applyScale` now uses `MustFloat64(params[0])`, matching the other numeric functions. `MustFloat64` already falls back to `strconv.ParseFloat` for strings, so template-substituted values keep working.
- Added `TestApplyScale` covering the numeric (freshly added default), string (typed), and invalid param cases.

### Notes

- Fixing this backend-side (rather than changing `defaultParams` to `['100']`) also repairs dashboards already saved with the numeric param - no retyping needed.
- No frontend changes; the frontend path already handles both types via `Number(param)`.