### PR TITLE
fix(problems): expand trigger description macros on the default query path

### DIFF
--- a/.changeset/olive-pans-repeat.md
+++ b/.changeset/olive-pans-repeat.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+Fix macros such as `{ITEM.VALUE}` showing unexpanded in the Problems panel Description. Since 6.4.1 the plugin asked Zabbix not to expand the trigger comment, but only expanded it itself when "Item value at problem time" was enabled, so the default query showed the raw macro text.

--- a/provisioning/dashboards/problems-description-macros-enabled.json
+++ b/provisioning/dashboards/problems-description-macros-enabled.json
@@ -1,0 +1,78 @@
+{
+  "uid": "e2e-problems-description-macros-enabled",
+  "title": "E2E Problems Description Macros Enabled",
+  "schemaVersion": 39,
+  "tags": [
+    "e2e"
+  ],
+  "timezone": "browser",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "alexanderzobnin-zabbix-triggers-panel",
+      "title": "Problems with macro in Description (item value at problem time)",
+      "datasource": {
+        "type": "alexanderzobnin-zabbix-datasource",
+        "uid": "zabbix-e2e"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "alexanderzobnin-zabbix-datasource",
+            "uid": "zabbix-e2e"
+          },
+          "refId": "A",
+          "queryType": "5",
+          "showProblems": "problems",
+          "resultFormat": "table",
+          "evaltype": "0",
+          "group": {
+            "filter": "E2E Macros"
+          },
+          "host": {
+            "filter": ""
+          },
+          "application": {
+            "filter": ""
+          },
+          "proxy": {
+            "filter": ""
+          },
+          "trigger": {
+            "filter": ""
+          },
+          "tags": {
+            "filter": ""
+          },
+          "item": {
+            "filter": ""
+          },
+          "itemTag": {
+            "filter": ""
+          },
+          "macro": {
+            "filter": ""
+          },
+          "options": {
+            "acknowledged": 2,
+            "minSeverity": 0,
+            "count": false,
+            "limit": 1001,
+            "useTimeRange": false,
+            "fetchHistoricalItemValue": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/provisioning/dashboards/problems-description-macros.json
+++ b/provisioning/dashboards/problems-description-macros.json
@@ -1,0 +1,78 @@
+{
+  "uid": "e2e-problems-description-macros",
+  "title": "E2E Problems Description Macros",
+  "schemaVersion": 39,
+  "tags": [
+    "e2e"
+  ],
+  "timezone": "browser",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "alexanderzobnin-zabbix-triggers-panel",
+      "title": "Problems with macro in Description",
+      "datasource": {
+        "type": "alexanderzobnin-zabbix-datasource",
+        "uid": "zabbix-e2e"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "alexanderzobnin-zabbix-datasource",
+            "uid": "zabbix-e2e"
+          },
+          "refId": "A",
+          "queryType": "5",
+          "showProblems": "problems",
+          "resultFormat": "table",
+          "evaltype": "0",
+          "group": {
+            "filter": "E2E Macros"
+          },
+          "host": {
+            "filter": ""
+          },
+          "application": {
+            "filter": ""
+          },
+          "proxy": {
+            "filter": ""
+          },
+          "trigger": {
+            "filter": ""
+          },
+          "tags": {
+            "filter": ""
+          },
+          "item": {
+            "filter": ""
+          },
+          "itemTag": {
+            "filter": ""
+          },
+          "macro": {
+            "filter": ""
+          },
+          "options": {
+            "acknowledged": 2,
+            "minSeverity": 0,
+            "count": false,
+            "limit": 1001,
+            "useTimeRange": false,
+            "fetchHistoricalItemValue": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
@@ -590,6 +590,41 @@ describe('Zabbix API connector', () => {
       });
     });
   });
+
+  describe('getTriggersByIds', () => {
+    beforeAll(() => {
+      jest.spyOn(ZabbixAPIConnector.prototype, 'initVersion').mockResolvedValue('');
+    });
+
+    const callParams = async (expandComment?: boolean) => {
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      zabbixAPIConnector.version = '7.0.0';
+      zabbixAPIConnector.request = jest.fn(() => Promise.resolve({}));
+
+      await (expandComment === undefined
+        ? zabbixAPIConnector.getTriggersByIds(['501'])
+        : zabbixAPIConnector.getTriggersByIds(['501'], expandComment));
+
+      const request = zabbixAPIConnector.request as jest.Mock;
+      expect(request.mock.calls[0][0]).toBe('trigger.get');
+      return request.mock.calls[0][1];
+    };
+
+    it('asks Zabbix to expand the trigger comment by default', async () => {
+      expect(await callParams()).toMatchObject({ expandComment: true });
+    });
+
+    it('omits expandComment rather than sending false', async () => {
+      // Zabbix treats the key as present-means-true, so sending false would still
+      // expand the comment and leave the per-problem expansion nothing to replace.
+      expect(await callParams(false)).not.toHaveProperty('expandComment');
+    });
+
+    it('keeps the neighbouring expand flags in both modes', async () => {
+      expect(await callParams(true)).toMatchObject({ expandDescription: true, expandData: true });
+      expect(await callParams(false)).toMatchObject({ expandDescription: true, expandData: true });
+    });
+  });
 });
 
 const triggers = [

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -632,12 +632,21 @@ export class ZabbixAPIConnector {
     return this.request('problem.get', params).then(utils.mustArray);
   }
 
-  async getTriggersByIds(triggerids: string[]) {
+  /**
+   * `expandComment` asks Zabbix to expand macros in the trigger comment, which the
+   * Problems panel renders as "Description". Pass false only when the caller expands
+   * those macros itself per problem, because that needs the raw template.
+   *
+   * The parameter must be omitted rather than sent as false. Zabbix treats the key
+   * as present-means-true and expands the comment even when the value is false.
+   */
+  async getTriggersByIds(triggerids: string[], expandComment = true) {
     const params = {
       output: 'extend',
       triggerids: triggerids,
       expandDescription: true,
       expandData: true,
+      ...(expandComment ? { expandComment: true } : {}),
       expandExpression: true,
       monitored: true,
       skipDependent: true,

--- a/src/datasource/zabbix/zabbix.test.ts
+++ b/src/datasource/zabbix/zabbix.test.ts
@@ -229,6 +229,18 @@ describe('Zabbix', () => {
 
       expect(zabbix.zabbixAPI.getHistory).toHaveBeenCalled();
     });
+
+    it('asks Zabbix to expand trigger comments when the history lookup is off', async () => {
+      await zabbix.getProblemsHistory('group.*', 'host.*', 'app.*', undefined, {});
+
+      expect(zabbix.zabbixAPI.getTriggersByIds).toHaveBeenCalledWith(['501'], true);
+    });
+
+    it('leaves trigger comments unexpanded when the history lookup will expand them per problem', async () => {
+      await zabbix.getProblemsHistory('group.*', 'host.*', 'app.*', undefined, { fetchHistoricalItemValue: true });
+
+      expect(zabbix.zabbixAPI.getTriggersByIds).toHaveBeenCalledWith(['501'], false);
+    });
   });
 
   describe('enrichProblemsWithItemHistory', () => {

--- a/src/datasource/zabbix/zabbix.ts
+++ b/src/datasource/zabbix/zabbix.ts
@@ -624,7 +624,12 @@ export class Zabbix implements ZabbixConnector {
       )
       .then((problems) => {
         const triggerids = problems?.map((problem) => problem.objectid);
-        return Promise.all([Promise.resolve(problems), this.zabbixAPI.getTriggersByIds(triggerids)]);
+        return Promise.all([
+          Promise.resolve(problems),
+          // Let Zabbix expand the comment macros unless the client-side
+          // enrichment below will do it per problem, which needs the raw template.
+          this.zabbixAPI.getTriggersByIds(triggerids, !options?.fetchHistoricalItemValue),
+        ]);
       })
       .then(([problems, triggers]) => joinTriggersWithProblems(problems, triggers))
       .then((problems) => (options?.fetchHistoricalItemValue ? this.enrichProblemsWithItemHistory(problems) : problems))
@@ -661,7 +666,12 @@ export class Zabbix implements ZabbixConnector {
       .then((query) => this.zabbixAPI.getEventsHistory(query.groupids, query.hostids, query.applicationids, options))
       .then((problems) => {
         const triggerids = problems?.map((problem) => problem.objectid);
-        return Promise.all([Promise.resolve(problems), this.zabbixAPI.getTriggersByIds(triggerids)]);
+        return Promise.all([
+          Promise.resolve(problems),
+          // Let Zabbix expand the comment macros unless the client-side
+          // enrichment below will do it per problem, which needs the raw template.
+          this.zabbixAPI.getTriggersByIds(triggerids, !options?.fetchHistoricalItemValue),
+        ]);
       })
       .then(([problems, triggers]) => joinTriggersWithEvents(problems, triggers, { valueFromEvent }))
       .then((problems) => (options?.fetchHistoricalItemValue ? this.enrichProblemsWithItemHistory(problems) : problems))

--- a/tests/e2e/problemsDescriptionMacros.spec.ts
+++ b/tests/e2e/problemsDescriptionMacros.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+/**
+ * End-to-end test for trigger Description macro expansion, against the real
+ * provisioned Zabbix backend.
+ *
+ * The Problems panel shows the Zabbix trigger `comments` field as "Description".
+ * The fixture seeds a trigger whose comments are `Current value: {ITEM.VALUE}`
+ * and one open problem on an item whose value is 42, so:
+ *
+ *   - With "Item value at problem time" OFF (default) Zabbix must expand the
+ *     macro server-side, and the panel must show a value rather than the macro.
+ *   - With it ON the plugin expands the macro itself, per problem, so the
+ *     request must NOT carry expandComment — Zabbix treats that key as
+ *     present-means-true and would expand the comment before the plugin sees it.
+ *
+ * Requires the e2e environment (docker-compose.yml) with seeded fixtures.
+ */
+
+const EXPANDED_DESCRIPTION = 'Current value: 42';
+const RAW_MACRO = '{ITEM.VALUE}';
+
+const isZabbixApi = (url: string) => url.includes('/resources/zabbix-api');
+const isMethod = (postData: string | null, method: string) => !!postData && postData.includes(`"${method}"`);
+
+const triggerGetParams = (postData: string) => {
+  const body = JSON.parse(postData);
+  return (body.params ?? body.data?.params) as Record<string, unknown>;
+};
+
+test('expands the Description macro without a history lookup by default', async ({
+  gotoDashboardPage,
+  readProvisionedDashboard,
+  page,
+}) => {
+  const dashboard = await readProvisionedDashboard({ fileName: 'problems-description-macros.json' });
+
+  const triggerGetRequest = page.waitForRequest(
+    (request) => isZabbixApi(request.url()) && isMethod(request.postData(), 'trigger.get'),
+    { timeout: 20000 }
+  );
+  let sawHistoryGet = false;
+  page.on('request', (request) => {
+    if (isZabbixApi(request.url()) && isMethod(request.postData(), 'history.get')) {
+      sawHistoryGet = true;
+    }
+  });
+
+  const dashboardPage = await gotoDashboardPage(dashboard);
+  await dashboardPage.waitForPanelsQueriesToComplete();
+
+  // Zabbix must be asked to expand the comment, so the fix costs no extra request.
+  const params = triggerGetParams((await triggerGetRequest).postData()!);
+  expect(params.expandComment).toBe(true);
+
+  const panel = page.getByRole('region', { name: 'Problems with macro in Description' });
+  await panel.getByRole('row').filter({ hasText: 'E2E macro trigger' }).locator('button:has(i.fa-info-circle)').click();
+
+  await expect(panel).toContainText(EXPANDED_DESCRIPTION);
+  await expect(panel).not.toContainText(RAW_MACRO);
+  expect(sawHistoryGet).toBe(false);
+});
+
+test('leaves the Description raw for the plugin to expand when the history lookup is enabled', async ({
+  gotoDashboardPage,
+  readProvisionedDashboard,
+  page,
+}) => {
+  const dashboard = await readProvisionedDashboard({ fileName: 'problems-description-macros-enabled.json' });
+
+  const triggerGetRequest = page.waitForRequest(
+    (request) => isZabbixApi(request.url()) && isMethod(request.postData(), 'trigger.get'),
+    { timeout: 20000 }
+  );
+
+  const dashboardPage = await gotoDashboardPage(dashboard);
+  await dashboardPage.waitForPanelsQueriesToComplete();
+
+  // The key must be absent, not false: Zabbix expands the comment whenever the
+  // key is present, which would leave the per-problem expansion nothing to replace.
+  const params = triggerGetParams((await triggerGetRequest).postData()!);
+  expect(params).not.toHaveProperty('expandComment');
+
+  const panel = page.getByRole('region', { name: 'Problems with macro in Description (item value at problem time)' });
+  await panel.getByRole('row').filter({ hasText: 'E2E macro trigger' }).locator('button:has(i.fa-info-circle)').click();
+
+  await expect(panel).toContainText(EXPANDED_DESCRIPTION);
+  await expect(panel).not.toContainText(RAW_MACRO);
+});

--- a/tests/fixtures/description-macros.sql
+++ b/tests/fixtures/description-macros.sql
@@ -1,0 +1,54 @@
+-- Deterministic e2e fixture for trigger Description macro expansion.
+--
+-- The Problems panel renders the Zabbix trigger `comments` field as
+-- "Description". This fixture creates a trigger whose comments hold a literal
+-- {ITEM.VALUE} macro plus one open problem, so a test can assert the panel
+-- shows the item value and not the raw macro text.
+--
+-- Self-contained and independent of seed.sql: its own host group, host, item
+-- and trigger, in a separate 9_000_10x id range. Fixtures load in lexicographic
+-- order, so this file must not depend on any other.
+--
+-- ON CONFLICT DO NOTHING keeps it idempotent.
+
+BEGIN;
+
+-- host group + host + membership
+INSERT INTO hstgrp (groupid, name, type) VALUES (9000101, 'E2E Macros', 0) ON CONFLICT DO NOTHING;
+INSERT INTO hosts (hostid, host, name, status) VALUES (9000101, 'e2e-macro-host', 'e2e-macro-host', 0) ON CONFLICT DO NOTHING;
+INSERT INTO hosts_groups (hostgroupid, hostid, groupid) VALUES (9000101, 9000101, 9000101) ON CONFLICT DO NOTHING;
+
+-- trapper item (type 2), unsigned (value_type 3) -> history_uint
+INSERT INTO items (itemid, hostid, type, key_, name, value_type, status, delay) VALUES
+  (9000101, 9000101, 2, 'e2e.macro.item', 'E2E macro item', 3, 0, '0')
+ON CONFLICT DO NOTHING;
+INSERT INTO item_rtdata (itemid, state) VALUES (9000101, 0) ON CONFLICT DO NOTHING;
+
+-- Trigger in PROBLEM state (value 1), enabled (status 0), High severity (priority 4).
+-- `comments` is the field the Problems panel shows as "Description".
+INSERT INTO triggers (triggerid, description, expression, value, status, priority, flags, comments) VALUES
+  (9000101, 'E2E macro trigger', '{9000101}=1', 1, 0, 4, 0, 'Current value: {ITEM.VALUE}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO functions (functionid, itemid, triggerid, name, parameter) VALUES
+  (9000101, 9000101, 9000101, 'last', '$')
+ON CONFLICT DO NOTHING;
+
+-- one open problem (source/object 0 = trigger, value 1 = PROBLEM)
+INSERT INTO events (eventid, source, object, objectid, clock, value, acknowledged, ns, name, severity) VALUES
+  (9000101, 0, 0, 9000101, EXTRACT(EPOCH FROM now())::int - 300, 1, 0, 0, 'E2E macro trigger', 4)
+ON CONFLICT DO NOTHING;
+
+-- r_eventid NULL => still open
+INSERT INTO problem (eventid, source, object, objectid, clock, ns, r_eventid, r_clock, r_ns, name, acknowledged, severity) VALUES
+  (9000101, 0, 0, 9000101, EXTRACT(EPOCH FROM now())::int - 300, 0, NULL, 0, 0, 'E2E macro trigger', 0, 4)
+ON CONFLICT DO NOTHING;
+
+-- History for the item. A single fixed value keeps the expanded Description
+-- deterministic, so the test can assert on the exact rendered string.
+INSERT INTO history_uint (itemid, clock, value, ns)
+SELECT 9000101, gs, 42, 0
+FROM generate_series(EXTRACT(EPOCH FROM now())::int - 3600, EXTRACT(EPOCH FROM now())::int, 300) AS gs
+ON CONFLICT DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- ask Zabbix to expand the trigger comment on `trigger.get`, so the Problems panel Description no longer shows raw `{ITEM.VALUE}` text with default query options
- keep the parameter off when "Item value at problem time" is enabled, so the plugin can still expand each problem's own value
- add unit coverage plus an e2e test and fixture against the seeded Zabbix backend

Since 6.4.1 neither side expanded these macros on the default path. #2404 removed `expandComment` from `trigger.get` so the plugin could expand the comment itself, per problem. #2460 then put that client-side expansion behind the "Item value at problem time" option, which is off by default, and did not restore the server-side flag.

**User-facing:** any trigger with a macro in its Description shows the expanded value again on the default query. Behaviour with "Item value at problem time" enabled is unchanged, and the default path still sends no `history.get`.

### Why the parameter is omitted rather than sent as false

Zabbix expands the comment whenever the `expandComment` key is present, regardless of its value. Sending `false` on the opt-in path would let Zabbix expand the comment with the item's current value before the plugin sees it, leaving the per-problem expansion nothing to replace.
