### PR TITLE
Prepare grafana-zabbix v6.7.0

### DIFF
--- a/.changeset/ten-owls-admire.md
+++ b/.changeset/ten-owls-admire.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Fix: Item tag regex matching no tags returns all items with Direct DB

--- a/.changeset/tiny-suns-kick.md
+++ b/.changeset/tiny-suns-kick.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': minor
----
-
-Add data links to the Problems panel table layout. Link titles and URLs support problem variables (`${host}`, `${name}`, `${description}`, `${severity}`, `${triggerid}`, `${eventid}`) and tag values via `${tag_<tag_name>}`.

--- a/.changeset/wet-chairs-wear.md
+++ b/.changeset/wet-chairs-wear.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Fix `$__range_series` and other range macros not being expanded in query function params (e.g. `percentile($__range_series, 95)`)

--- a/.changeset/witty-bears-wait.md
+++ b/.changeset/witty-bears-wait.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Switch to npm as package manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 6.7.0
+
+### Minor Changes
+
+🚀 Add data links to the Problems panel table layout. Link titles and URLs support problem variables (`${host}`, `${name}`, `${description}`, `${severity}`, `${triggerid}`, `${eventid}`) and tag values via `${tag_<tag_name>}`.
+
+### Patch Changes
+
+⚙️ Chore: bump transitive fast-uri to 3.1.7 to address CVE-2026-76172, CVE-2026-75975, CVE-2026-75931, and CVE-2026-75899
+⚙️ Chore: update backend dependencies, including google.golang.org/grpc 1.83.2 (CVE-2026-84304)
+🐛 Fix: Item tag regex matching no tags returns all items with Direct DB
+🐛 Fix `$__range_series` and other range macros not being expanded in query function params (e.g. `percentile($__range_series, 95)`)
+🐛 Switch to npm as package manager
+
 ## 6.6.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -9988,9 +9988,9 @@
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {


### PR DESCRIPTION
## Summary
- Bump plugin version to **6.7.0** via `changeset version` (pending minor for problems-panel data links, plus patches already queued on main).
- Patch remaining HIGH `fast-uri` CVEs from [grafana/data-sources#1853](https://github.com/grafana/data-sources/issues/1853) with a lockfile-only natural re-resolution (`^3.0.1` → **3.1.7**, same major; CVE floor is 3.1.6).
- Changelog also notes the already-merged backend bump in #2503 (`google.golang.org/grpc` 1.83.2 / CVE-2026-84304).

| Package | From | To | Strategy | CVEs |
|---|---|---|---|---|
| `fast-uri` (transitive via `ajv`) | 3.1.5 | 3.1.7 | natural (`npm update`) | CVE-2026-76172, CVE-2026-75975, CVE-2026-75931, CVE-2026-75899 |

Renovate #2515 (`fix(deps): update frontend dependencies`) does not move `fast-uri`; no overlap.

## Test plan
- [x] `npm ci --ignore-scripts`
- [x] `npm run typecheck`
- [x] `npm run test:ci` (21 suites / 307 tests)
- [x] `npm run build`
- [x] `mage -v`
- [ ] CI on this PR (plugin CI + Playwright + Zabbix integration)

After merge, publish via the [Plugins CD workflow](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#cd_1).